### PR TITLE
feat: Add Kanji input functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
 
     
     <script src="js/bootstrap.bundle.min.js"></script>
-    <script src="js/wanakana.min.js"></script>
+    <script src="js/jsNihonIME.js"></script>
     <script src="js/sql-wasm.js"></script>
     <script src="js/script.js"></script>
 

--- a/js/jsNihonIME.js
+++ b/js/jsNihonIME.js
@@ -1,0 +1,613 @@
+/**
+ * Copyright (c) 2007, 2011, Fernando Lucchesi Bastos Jurema
+ * This code is under the MIT license: http://creativecommons.org/licenses/MIT/deed.en
+ *
+ * http://www.students.ic.unicamp.br/~ra091187/
+ * fernandolbastos [at] gmail [dot] com
+ *
+ * This virtual keyboard is free software.
+ * Basically, you can use, copy, modify and distribute it in any way.
+ */
+
+/**
+ * The kanji information was taken from Taka:
+ * http://sourceforge.net/projects/taka/
+ */
+
+
+/**
+ * HOW TO USE:
+ *
+ * First, put the following code at the <home> tag of your page:
+ *
+ *
+
+<!-- JavaScript code that does all the work -->
+<script type="text/JavaScript" src="tecladojapones.js"></script>
+<!-- Defining the size of the buttons and of the div that will hold them -->
+<style type="text/css"> #divbuttons{width: 520px;} .btn {width: 28px;} </style>
+
+ *
+ *
+ * then, put this were you want the keyboard to be rendered:
+ *
+ *
+
+<!-- Combobox to select the buttons -->
+<select name="chars" size="1" onchange="changebuttons(this);">
+	<option>Hiragana</option>
+	<option>Katakana</option>
+	<option>Jouyou Kanji - 1</option>
+	<option>Jouyou Kanji - 2</option>
+	<option>Jouyou Kanji - 3</option>
+	<option>Jouyou Kanji - 4</option>
+	<option>Jouyou Kanji - 5</option>
+	<option>Jouyou Kanji - 6</option>
+	<option>Jouyou Kanji - 7</option>
+	<option>No buttons</option>
+</select><br />
+
+<!-- div that will hold the buttons -->
+<div id="divbuttons"></div>
+
+<!-- Textarea -->
+<textarea id="k_textarea" rows="12" cols="60"  onkeydown="javascript:replacekana();" onkeyup="javascript:replacekana();"></textarea><br />
+
+ *
+ *
+ * and that's all!
+ *
+ * You are free to change the text of the combobox, as the code
+ * will only consider the position of the option.
+ *
+ *
+ * If you want, you can just put all the code together, but it's not
+ * good practice(i.e. your page will not validate at W3C).
+ *
+ * The kanji will not work offline, as the xml can only be read in http.
+ */
+
+/*
+ * TO DO:
+ * Deal with the massive amount of kanji at the higher levels...
+ */
+
+/**
+ * BEGIN CODE:
+ */
+
+
+/**
+ * Defines wich button category will be shown at the beginning.
+ * Uncomment the desired line(and comment the other) to change it.
+ * Comment all of them for no buttons.
+ */
+window.onload = hiragana;
+//window.onload = katakana;
+//window.onload = kanji(1); // Change the number to select the level
+
+
+// Temporary variable that keeps the buttons code
+// (for efficiency, changing the div's code directly is too slow)
+var Buttons_tmp="";
+
+
+/* Function that renders a kanji button */
+function kanji_btn(symbol, meaning, on_yomi, kun_yomi)
+{
+	// Model: <input class=\"btn\" type="button" value="&#26085;" title="Sol, dia (hi)" onclick="javascript:add('&#26085;')">
+	Buttons_tmp +=
+		'<input class="btn" type="button" value="' + symbol +
+		'" title="' + meaning +
+		'\nO: ' + on_yomi +
+		'\nK: ' + kun_yomi +
+		'" onclick="javascript:add(\'' + symbol + '\')">\n';
+}
+
+
+/* Function that adds the button symbol to the textarea */
+function add(symbol)
+{
+	document.getElementById("k_textarea").value += symbol;
+}
+
+
+/* Function that changes the buttons according to the combobox */
+function changebuttons(sel)
+{
+	switch(sel.selectedIndex)
+	{
+		case 0:
+			hiragana();
+			break;
+		case 1:
+			katakana();
+			break;
+		case 9:
+			// No buttons
+			document.getElementById("divbuttons").innerHTML = "";
+			break;
+		default:
+			kanji(sel.selectedIndex - 1);
+			break;
+	}
+}
+
+
+/* Function that renders the kanji buttons of the chosen level */
+var kanjiData;
+
+function kanji(lvl)
+{
+	// Empties the temporary string
+	Buttons_tmp = "";
+
+	if (!kanjiData) {
+		// Opens the xml file containign the kanji
+		if (window.XMLHttpRequest)
+		{// code for IE7+, Firefox, Chrome, Opera, Safari
+			xmlhttp=new XMLHttpRequest();
+		}
+		else
+		{// code for IE6, IE5
+			xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
+		}
+		xmlhttp.open("GET","js/kanji.xml",false);
+		xmlhttp.send();
+		kanjiData=xmlhttp.responseXML;
+	}
+
+	// Gets the kanji of that level
+	kanji_list = kanjiData.getElementsByTagName("category")[lvl-1].getElementsByTagName("kanji");
+
+	const result = [];
+	// For each kanji
+	for (i=0; i < kanji_list.length; i++)
+	{
+		// Gets its data
+		kanji_char = kanji_list[i].getElementsByTagName("char")[0].childNodes[0].nodeValue;
+		meaning = kanji_list[i].getElementsByTagName("meaning")[0].childNodes[0].nodeValue;
+		on_list = kanji_list[i].getElementsByTagName("on");
+		kun_list = kanji_list[i].getElementsByTagName("kun");
+
+		// Strings that will hold the readings
+		on = "";
+		kun = "";
+
+		// Gets the readings, separated by commas
+		for (j=0; j < on_list.length; j++)
+		{
+			// &#12289; = japanese comma
+			if( on == "" )
+				on = on_list[j].childNodes[0].nodeValue;
+			else
+				on = on + "," + on_list[j].childNodes[0].nodeValue;
+		}
+		for (j=0; j < kun_list.length; j++)
+		{
+			if( kun == "" )
+				kun = kun_list[j].childNodes[0].nodeValue;
+			else
+				kun = kun + "," + kun_list[j].childNodes[0].nodeValue;
+		}
+
+		result.push({char: kanji_char, meaning: meaning, on: on, kun: kun});
+		// Generates the button code onto the tmp string
+		kanji_btn(kanji_char, meaning, on, kun);
+	}
+
+	// Draws the buttons inside the div
+	document.getElementById("divbuttons").innerHTML = Buttons_tmp;
+	return result;
+}
+
+
+/* Function that renders a kana button */
+function kana(symbol, reading)
+{
+	Buttons_tmp +=
+		'<input class="btn" type="button" value="' + symbol +
+		'" title="' + reading +
+		'" onclick="javascript:add(\'' + symbol + '\')">\n';
+}
+
+
+/* Auxiliary functions, for formatting */
+function br() { Buttons_tmp += "<br />"; }
+function nbsp2() { Buttons_tmp += "&nbsp;&nbsp;"; }
+
+
+/* Function that renders the hiragana buttons */
+function hiragana()
+{
+	// Empties the temporary string
+	Buttons_tmp = "";
+
+	kana("&#12354;", "a"); kana("&#12356;", "i"); kana("&#12358;", "u"); kana("&#12360;", "e"); kana("&#12362;", "o");
+	nbsp2();
+	kana("&#12363;", "ka"); kana("&#12365;", "ki"); kana("&#12367;", "ku"); kana("&#12369;", "ke"); kana("&#12371;", "ko");
+	nbsp2()
+	kana("&#12373;", "sa"); kana("&#12375;", "shi"); kana("&#12377;", "su"); kana("&#12379;", "se"); kana("&#12381;", "so");
+	br();
+	kana("&#12383;", "ta"); kana("&#12385;", "chi"); kana("&#12388;", "tsu"); kana("&#12390;", "te"); kana("&#12392;", "to");
+	nbsp2();
+	kana("&#12394;", "na"); kana("&#12395;", "ni"); kana("&#12396;", "nu"); kana("&#12397;", "ne"); kana("&#12398;", "no");
+	nbsp2();
+	kana("&#12399;", "ha"); kana("&#12402;", "hi"); kana("&#12405;", "fu"); kana("&#12408;", "he"); kana("&#12411;", "ho");
+	br();
+	kana("&#12414;", "ma"); kana("&#12415;", "mi"); kana("&#12416;", "mu"); kana("&#12417;", "me"); kana("&#12418;", "mo");
+	nbsp2();
+	kana("&#12425;", "ra"); kana("&#12426;", "ri"); kana("&#12427;", "ru"); kana("&#12428;", "re"); kana("&#12429;", "ro");
+	nbsp2();
+	kana("&#12364;", "ga"); kana("&#12366;", "gi"); kana("&#12368;", "gu"); kana("&#12370;", "ge"); kana("&#12372;", "go");
+	br();
+	kana("&#12374;", "za"); kana("&#12376;", "ji"); kana("&#12378;", "zu"); kana("&#12380;", "ze"); kana("&#12382;", "zo");
+	nbsp2();
+	kana("&#12384;", "da"); kana("&#12376;", "ji"); kana("&#12389;", "(zu)"); kana("&#12391;", "de"); kana("&#12393;", "do");
+	nbsp2();
+	kana("&#12400;", "ba"); kana("&#12403;", "bi"); kana("&#12406;", "bu"); kana("&#12409;", "be"); kana("&#12412;", "bo");
+	br();
+	kana("&#12401;", "pa"); kana("&#12404;", "pi"); kana("&#12407;", "pu"); kana("&#12410;", "pe"); kana("&#12413;", "po");
+	nbsp2();
+	kana("&#12353;", "'a"); kana("&#12355;", "'i"); kana("&#12357;", "'u"); kana("&#12359;", "'e"); kana("&#12361;", "'o");
+	nbsp2();
+	kana("&#12420;", "ya"); kana("&#12422;", "yu"); kana("&#12424;", "yo");
+	br();
+	kana("&#12419;", "'ya"); kana("&#12421;", "'yu"); kana("&#12423;", "'yo");
+	nbsp2();
+	kana("&#12431;", "wa"); kana("&#12434;", "(w)o"); kana("&#12435;", "n");
+
+	document.getElementById("divbuttons").innerHTML = Buttons_tmp;
+}
+
+
+/* Function that renders the katakana buttons */
+function katakana()
+{
+	// Empties the temporary string
+	Buttons_tmp = "";
+
+	kana("&#12450;", "a"); kana("&#12452;", "i"); kana("&#12454;", "u"); kana("&#12456;", "e"); kana("&#12458;", "o");
+	nbsp2();
+	kana("&#12459;", "ka"); kana("&#12461;", "ki"); kana("&#12463;", "ku"); kana("&#12465;", "ke"); kana("&#12467;", "ko");
+	nbsp2();
+	kana("&#12469;", "sa"); kana("&#12471;", "shi"); kana("&#12473;", "su"); kana("&#12475;", "se"); kana("&#12477;", "so");
+	br();
+	kana("&#12479;", "ta"); kana("&#12481;", "chi"); kana("&#12484;", "tsu"); kana("&#12486;", "te"); kana("&#12488;", "to");
+	nbsp2();
+	kana("&#12490;", "na"); kana("&#12491;", "ni"); kana("&#12492;", "nu"); kana("&#12493;", "ne"); kana("&#12494;", "no");
+	nbsp2();
+	kana("&#12495;", "ha"); kana("&#12498;", "hi"); kana("&#12501;", "fu"); kana("&#12504;", "he"); kana("&#12507;", "ho");
+	br();
+	kana("&#12510;", "ma"); kana("&#12511;", "mi"); kana("&#12512;", "mu"); kana("&#12513;", "me"); kana("&#12514;", "mo");
+	nbsp2();
+	kana("&#12521;", "ra"); kana("&#12522;", "ri"); kana("&#12523;", "ru"); kana("&#12524;", "re"); kana("&#12525;", "ro");
+	nbsp2();
+	kana("&#12460;", "ga"); kana("&#12462;", "gi"); kana("&#12464;", "gu"); kana("&#12466;", "ge"); kana("&#12468;", "go");
+	br();
+	kana("&#12470;", "za"); kana("&#12472;", "ji"); kana("&#12474;", "zu"); kana("&#12476;", "ze"); kana("&#12478;", "zo");
+	nbsp2();
+	kana("&#12480;", "da"); kana("&#12472;", "ji"); kana("&#12485;", "(zu)"); kana("&#12487;", "de"); kana("&#12489;", "do");
+	nbsp2();
+	kana("&#12496;", "ba"); kana("&#12499;", "bi"); kana("&#12502;", "bu"); kana("&#12505;", "be"); kana("&#12508;", "bo");
+	br();
+	kana("&#12497;", "pa"); kana("&#12500;", "pi"); kana("&#12503;", "pu"); kana("&#12506;", "pe"); kana("&#12509;", "po");
+	nbsp2();
+	kana("&#12449;", "'a"); kana("&#12451;", "'i"); kana("&#12453;", "'u"); kana("&#12455;", "'e"); kana("&#12457;", "'o");
+	nbsp2();
+	kana("&#12516;", "ya"); kana("&#12518;", "yu"); kana("&#12520;", "yo");
+	br();
+	kana("&#12515;", "'ya"); kana("&#12517;", "'yu"); kana("&#12519;", "'yo");
+	nbsp2();
+	kana("&#12527;", "wa"); kana("&#12530;", "(w)o"); kana("&#12531;", "n");
+
+	document.getElementById("divbuttons").innerHTML = Buttons_tmp;
+}
+
+
+/* Function that replaces the roman letters for their corresponding kana */
+function replacekana()
+{
+	// Temporary variable, for efficiency
+	str = document.getElementById("k_textarea").value;
+
+
+	/*---HIRAGANA; KATAKANA;---*/
+
+	// l=r
+	str = str.replace("l","r");	str = str.replace("L","R");
+
+	/* little tsu */
+	// by putting a 't' before:
+	str = str.replace("tk","\u3063k");	str = str.replace("TK","\u30C3K");
+	// [ts] wouldn't work because of [tsu]
+	str = str.replace("tt","\u3063t");	str = str.replace("TT","\u30C3T");
+	str = str.replace("tn","\u3063n");	str = str.replace("TN","\u30C3N");
+	str = str.replace("th","\u3063h");	str = str.replace("TH","\u30C3H");
+	str = str.replace("tm","\u3063m");	str = str.replace("TM","\u30C3M");
+	str = str.replace("ty","\u3063y");	str = str.replace("TY","\u30C3Y");
+	str = str.replace("tr","\u3063r");	str = str.replace("TR","\u30C3R");
+	str = str.replace("tw","\u3063w");	str = str.replace("TW","\u30C3W");
+	str = str.replace("tg","\u3063g");	str = str.replace("TG","\u30C3G");
+	str = str.replace("tz","\u3063z");	str = str.replace("TZ","\u30C3Z");
+	str = str.replace("td","\u3063d");	str = str.replace("TD","\u30C3D");
+	str = str.replace("tb","\u3063b");	str = str.replace("TB","\u30C3B");
+	str = str.replace("tf","\u3063f");	str = str.replace("TF","\u30C3F");
+	str = str.replace("tp","\u3063p");	str = str.replace("TP","\u30C3P");
+	str = str.replace("tj","\u3063j");	str = str.replace("TJ","\u30C3J");
+	// by repeating consonants:
+	str = str.replace("kk","\u3063k");	str = str.replace("KK","\u30C3K");
+	str = str.replace("ss","\u3063s");	str = str.replace("SS","\u30C3S");
+	// str = str.replace("tt","\u3063t"); // Already taken care of
+	//str = str.replace("nn","\u3063n");	str = str.replace("NN","\u30C3N");
+	str = str.replace("hh","\u3063h");	str = str.replace("HH","\u30C3H");
+	str = str.replace("mm","\u3063m");	str = str.replace("MM","\u30C3M");
+	str = str.replace("yy","\u3063y");	str = str.replace("YY","\u30C3Y");
+	str = str.replace("rr","\u3063r");	str = str.replace("RR","\u30C3R");
+	str = str.replace("ww","\u3063w");	str = str.replace("WW","\u30C3W");
+	str = str.replace("gg","\u3063g");	str = str.replace("GG","\u30C3G");
+	str = str.replace("zz","\u3063z");	str = str.replace("ZZ","\u30C3Z");
+	str = str.replace("dd","\u3063d");	str = str.replace("DD","\u30C3D");
+	str = str.replace("bb","\u3063b");	str = str.replace("BB","\u30C3B");
+	str = str.replace("ff","\u3063f");	str = str.replace("FF","\u30C3F");
+	str = str.replace("pp","\u3063p");	str = str.replace("PP","\u30C3P");
+	str = str.replace("jj","\u3063j");	str = str.replace("JJ","\u30C3J");
+
+	// ka
+	str = str.replace("ka","\u304B");	str = str.replace("KA","\u30AB");
+	str = str.replace("ki","\u304D");	str = str.replace("KI","\u30AD");
+	str = str.replace("ku","\u304F");	str = str.replace("KU","\u30AF");
+	str = str.replace("ke","\u3051");	str = str.replace("KE","\u30B1");
+	str = str.replace("ko","\u3053");	str = str.replace("KO","\u30B3");
+
+	// ta
+	str = str.replace("ta","\u305F");	str = str.replace("TA","\u30BF");
+	str = str.replace("chi","\u3061");	str = str.replace("CHI","\u30C1");
+	str = str.replace("ti","\u3066\u3043");	str = str.replace("TI","\u30C6\u30A3");
+	str = str.replace("tsu","\u3064");	str = str.replace("TSU","\u30C4");
+	str = str.replace("te","\u3066");	str = str.replace("TE","\u30C6");
+	str = str.replace("to","\u3068");	str = str.replace("TO","\u30C8");
+
+	// sa (after ta because of [tsu], that would render t[su])
+	str = str.replace("sa","\u3055");	str = str.replace("SA","\u30B5");
+	str = str.replace("si","\u3057");	str = str.replace("SI","\u30B7");
+	str = str.replace("shi","\u3057");	str = str.replace("SHI","\u30B7");
+	str = str.replace("su","\u3059");	str = str.replace("SU","\u30B9");
+	str = str.replace("se","\u305B");	str = str.replace("SE","\u30BB");
+	str = str.replace("so","\u305D");	str = str.replace("SO","\u30BD");
+
+	// na
+	str = str.replace("na","\u306A");	str = str.replace("NA","\u30CA");
+	str = str.replace("ni","\u306B");	str = str.replace("NI","\u30CB");
+	str = str.replace("nu","\u306C");	str = str.replace("NU","\u30CC");
+	str = str.replace("ne","\u306D");	str = str.replace("NE","\u30CD");
+	str = str.replace("no","\u306E");	str = str.replace("NO","\u30CE");
+
+	// ma
+	str = str.replace("ma","\u307E");	str = str.replace("MA","\u30DE");
+	str = str.replace("mi","\u307F");	str = str.replace("MI","\u30DF");
+	str = str.replace("mu","\u3080");	str = str.replace("MU","\u30E0");
+	str = str.replace("me","\u3081");	str = str.replace("ME","\u30E1");
+	str = str.replace("mo","\u3082");	str = str.replace("MO","\u30E2");
+
+	// ra
+	str = str.replace("ra","\u3089");	str = str.replace("RA","\u30E9");
+	str = str.replace("ri","\u308A");	str = str.replace("RI","\u30EA");
+	str = str.replace("ru","\u308B");	str = str.replace("RU","\u30EB");
+	str = str.replace("re","\u308C");	str = str.replace("RE","\u30EC");
+	str = str.replace("ro","\u308D");	str = str.replace("RO","\u30ED");
+
+	// ga
+	str = str.replace("ga","\u304C");	str = str.replace("GA","\u30AC");
+	str = str.replace("gi","\u304E");	str = str.replace("GI","\u30AE");
+	str = str.replace("gu","\u3050");	str = str.replace("GU","\u30B0");
+	str = str.replace("ge","\u3052");	str = str.replace("GE","\u30B2");
+	str = str.replace("go","\u3054");	str = str.replace("GO","\u30B4");
+
+	// da (before za because of ['ji] and ['zu])
+	str = str.replace("da","\u3060");	str = str.replace("DA","\u30C0");
+	str = str.replace("'ji","\u3062");	str = str.replace("'JI","\u30C2");
+	str = str.replace("di","\u3062");	str = str.replace("DI","\u30C2");
+	str = str.replace("'zu","\u3065");	str = str.replace("'ZU","\u30C5");
+	str = str.replace("du","\u3065");	str = str.replace("DU","\u30C5");
+	str = str.replace("de","\u3067");	str = str.replace("DE","\u30C7");
+	str = str.replace("do","\u3069");	str = str.replace("DO","\u30C9");
+
+	// za
+	str = str.replace("za","\u3056");	str = str.replace("ZA","\u30B6");
+	str = str.replace("zi","\u3058");	str = str.replace("ZI","\u30B8");
+	str = str.replace("ji","\u3058");	str = str.replace("JI","\u30B8");
+	str = str.replace("zu","\u305A");	str = str.replace("ZU","\u30BA");
+	str = str.replace("ze","\u305C");	str = str.replace("ZE","\u30BC");
+	str = str.replace("zo","\u305E");	str = str.replace("ZO","\u30BE");
+
+	// ba
+	str = str.replace("ba","\u3070");	str = str.replace("BA","\u30D0");
+	str = str.replace("bi","\u3073");	str = str.replace("BI","\u30D3");
+	str = str.replace("bu","\u3076");	str = str.replace("BU","\u30D6");
+	str = str.replace("be","\u3079");	str = str.replace("BE","\u30D9");
+	str = str.replace("bo","\u307C");	str = str.replace("BO","\u30DC");
+
+	// pa
+	str = str.replace("pa","\u3071");	str = str.replace("PA","\u30D1");
+	str = str.replace("pi","\u3074");	str = str.replace("PI","\u30D4");
+	str = str.replace("pu","\u3077");	str = str.replace("PU","\u30D7");
+	str = str.replace("pe","\u307A");	str = str.replace("PE","\u30DA");
+	str = str.replace("po","\u307D");	str = str.replace("PO","\u30DD");
+
+	// wa
+	str = str.replace("wa","\u308F");	str = str.replace("WA","\u30EF");
+	str = str.replace("wo","\u3092");	str = str.replace("WO","\u30F2");
+
+	/* n */
+	// by putting a 'n' before
+	str = str.replace("nk","\u3093k");	str = str.replace("NK","\u30F3K");
+	str = str.replace("ns","\u3093s");	str = str.replace("NS","\u30F3S");
+	str = str.replace("nt","\u3093t");	str = str.replace("NT","\u30F3T");
+	str = str.replace("nn","\u3093n");	str = str.replace("NN","\u30F3N");
+	str = str.replace("nh","\u3093h");	str = str.replace("NH","\u30F3H");
+	str = str.replace("nm","\u3093m");	str = str.replace("NM","\u30F3M");
+	// [ny] wouldn't work because of [nya]
+	str = str.replace("nr","\u3093r");	str = str.replace("NR","\u30F3R");
+	str = str.replace("nw","\u3093w");	str = str.replace("MW","\u30F3W");
+	str = str.replace("ng","\u3093g");	str = str.replace("NG","\u30F3G");
+	str = str.replace("nz","\u3093z");	str = str.replace("NZ","\u30F3Z");
+	str = str.replace("nd","\u3093d");	str = str.replace("ND","\u30F3D");
+	str = str.replace("nj","\u3093j");	str = str.replace("NJ","\u30F3J");
+	str = str.replace("nb","\u3093b");	str = str.replace("NB","\u30F3B");
+	str = str.replace("np","\u3093p");	str = str.replace("NP","\u30F3P");
+	// special character combinations
+	str = str.replace("\xf1","\u3093");	str = str.replace("\xd1","\u30F3");
+	str = str.replace("\xe7","\u3093");	str = str.replace("\xc7","\u30F3");
+	str = str.replace("'n","\u3093");	str = str.replace("'N","\u30F3");
+	str = str.replace("n'","\u3093");	str = str.replace("'N","\u30F3");
+	str = str.replace("n ","\u3093");	str = str.replace("N ","\u30F3");
+
+	// fa
+	str = str.replace("fa","\u3075\u3041");	str = str.replace("FA","\u30D5\u30A1");
+	str = str.replace("fi","\u3075\u3043");	str = str.replace("FI","\u30D5\u30A3");
+	str = str.replace("fe","\u3075\u3047");	str = str.replace("FE","\u30D5\u30A7");
+	str = str.replace("fo","\u3075\u3049");	str = str.replace("FO","\u30D5\u30A9");
+
+	// ja
+	str = str.replace("ja","\u3058\u3041");	str = str.replace("JA","\u30B8\u30A1");
+	str = str.replace("ju","\u3058\u3045");	str = str.replace("JU","\u30B8\u30A5");
+	str = str.replace("je","\u3058\u3047");	str = str.replace("JE","\u30B8\u30A7");
+	str = str.replace("jo","\u3058\u3049");	str = str.replace("JO","\u30B8\u30A9");
+
+	// kya
+	str = str.replace("kya","\u304D\u3083");	str = str.replace("KYA","\u30AD\u30E3");
+	str = str.replace("kyu","\u304D\u3085");	str = str.replace("KYU","\u30AD\u30E5");
+	str = str.replace("kyo","\u304D\u3087");	str = str.replace("KYO","\u30AD\u30E7");
+
+	// sha
+	str = str.replace("sha","\u3057\u3083");	str = str.replace("SHA","\u30B7\u30E3");
+	str = str.replace("shu","\u3057\u3085");	str = str.replace("SHU","\u30B7\u30E5");
+	str = str.replace("sho","\u3057\u3087");	str = str.replace("SHO","\u30B7\u30E7");
+
+	// cha
+	str = str.replace("cha","\u3061\u3083");	str = str.replace("CHA","\u30C1\u30E3");
+	str = str.replace("chu","\u3061\u3085");	str = str.replace("CHU","\u30C1\u30E5");
+	str = str.replace("cho","\u3061\u3087");	str = str.replace("CHO","\u30C1\u30E7");
+
+	// nya
+	str = str.replace("nya","\u306B\u3083");	str = str.replace("NYA","\u30CB\u30E3");
+	str = str.replace("nyu","\u306B\u3085");	str = str.replace("NYU","\u30CB\u30E5");
+	str = str.replace("nyo","\u306B\u3087");	str = str.replace("NYO","\u30CB\u30E7");
+
+	// hya
+	str = str.replace("hya","\u3072\u3083");	str = str.replace("HYA","\u30D2\u30E3");
+	str = str.replace("hyu","\u3072\u3085");	str = str.replace("HYU","\u30D2\u30E5");
+	str = str.replace("hyo","\u3072\u3087");	str = str.replace("HYO","\u30D2\u30E7");
+
+	// mya
+	str = str.replace("mya","\u307F\u3083");	str = str.replace("MYA","\u30DF\u30E3");
+	str = str.replace("myu","\u307F\u3085");	str = str.replace("MYU","\u30DF\u30E5");
+	str = str.replace("myo","\u307F\u3087");	str = str.replace("MYO","\u30DF\u30E7");
+
+	// rya
+	str = str.replace("rya","\u308A\u3083");	str = str.replace("RYA","\u30EA\u30E3");
+	str = str.replace("ryu","\u308A\u3085");	str = str.replace("RYU","\u30EA\u30E5");
+	str = str.replace("ryo","\u308A\u3087");	str = str.replace("RYO","\u30EA\u30E7");
+
+	// gya
+	str = str.replace("gya","\u304E\u3083");	str = str.replace("GYA","\u30AE\u30E3");
+	str = str.replace("gyu","\u304E\u3085");	str = str.replace("GYU","\u30AE\u30E5");
+	str = str.replace("gyo","\u304E\u3087");	str = str.replace("GYO","\u30AE\u30E7");
+
+	// zya
+	str = str.replace("zya","\u3058\u3083");	str = str.replace("ZYA","\u30B8\u30E3");
+	str = str.replace("zyu","\u3058\u3085");	str = str.replace("ZYU","\u30B8\u30E5");
+	str = str.replace("zyo","\u3058\u3087");	str = str.replace("ZYO","\u30B8\u30E7");
+
+	// bya
+	str = str.replace("bya","\u3073\u3083");	str = str.replace("BYA","\u30D3\u30E3");
+	str = str.replace("byu","\u3073\u3085");	str = str.replace("BYU","\u30D3\u30E5");
+	str = str.replace("byo","\u3073\u3087");	str = str.replace("BYO","\u30D3\u30E7");
+
+	// pya
+	str = str.replace("pya","\u3074\u3083");	str = str.replace("PYA","\u30D4\u30E3");
+	str = str.replace("pyu","\u3074\u3085");	str = str.replace("PYU","\u30D4\u30E5");
+	str = str.replace("pyo","\u3074\u3087");	str = str.replace("PYO","\u30D4\u30E7");
+
+	// ha (at the end because of [sha] and [cha])
+	str = str.replace("ha","\u306F");	str = str.replace("HA","\u30CF");
+	str = str.replace("hi","\u3072");	str = str.replace("HI","\u30D2");
+	str = str.replace("fu","\u3075");	str = str.replace("FU","\u30D5");
+	str = str.replace("hu","\u3075");	str = str.replace("HU","\u30D5");
+	str = str.replace("he","\u3078");	str = str.replace("HE","\u30D8");
+	str = str.replace("ho","\u307B");	str = str.replace("HO","\u30DB");
+
+	// ya
+	str = str.replace("ya","\u3084");	str = str.replace("YA","\u30E4");
+	str = str.replace("yu","\u3086");	str = str.replace("YU","\u30E6");
+	str = str.replace("yo","\u3088");	str = str.replace("YO","\u30E8");
+
+	// vowel
+	str = str.replace("a","\u3042");	str = str.replace("A","\u30A2");
+	str = str.replace("i","\u3044");	str = str.replace("I","\u30A4");
+	str = str.replace("u","\u3046");	str = str.replace("U","\u30A6");
+	str = str.replace("e","\u3048");	str = str.replace("E","\u30A8");
+	str = str.replace("o","\u304A");	str = str.replace("O","\u30AA");
+
+
+	// Consonant by itself => consonant with an 'u' (I'm yet to find a way of making this work...)
+	/*
+	   str = str.replace("k","\u304F");
+	   str = str.replace("s","\u3059");
+	   str = str.replace("t","\u3068");
+	   str = str.replace("n","\u3093");
+	   str = str.replace("m","\u3080");
+	   str = str.replace("r","\u308B");
+	   str = str.replace("g","\u3050");
+	   str = str.replace("z","\u305A");
+	   str = str.replace("d","\u3065");
+	   str = str.replace("b","\u3076");
+	   str = str.replace("p","\u3077");
+	 */
+
+	/*---Other Characters---*/
+	str = str.replace(",","\u3001"); // comma
+	str = str.replace(".","\u3002"); // period
+
+	// Simple quote
+	//str = str.replace("' ","\u300C");
+	//str = str.replace(" '","\u300D");
+	str = str.replace("[","\u300C");
+	str = str.replace("]","\u300D");
+
+	// Double quotes
+	str = str.replace("\" ","\u300E");
+	str = str.replace(" \"","\u300F");
+
+
+
+	// Braces
+	str = str.replace("{","\uFF5B"); // {
+	str = str.replace("}","\uFF5D"); // }
+
+	// Parentheses
+	str = str.replace("(","\uFF08"); // (
+	str = str.replace(")","\uFF09"); // )
+
+	// Square brackets (used for quotes)
+	//str = str.replace("[","\uFF3B"); // [
+	//str = str.replace("]","\uFF3D"); // ]
+
+	// Lenticular brackets
+	str = str.replace("<","\u3010");
+	str = str.replace(">","\u3011");
+
+
+	str = str.replace("-","\u30FC"); // long vowel mark
+	str = str.replace("!","\uFF01"); // exclamation mark
+	str = str.replace("*","\uFF0A"); // asterisk
+	str = str.replace("?","\uFF1F"); // question mark
+	str = str.replace("@","\uFF20"); // at sign
+	//str = str.replace("~","\uFF5E"); // tilde
+	str = str.replace("~","\u301C"); // tilde
+
+
+	// Puts the temporary variable inside of the textbox
+	document.getElementById("k_textarea").value = str;
+}

--- a/js/kanji.xml
+++ b/js/kanji.xml
@@ -1,0 +1,13281 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<characters>
+	<category id="kanji_1">
+		<kanji>
+			<char>一</char>
+			<meaning>One</meaning>
+			<on>イツ</on>
+			<kun>ひと・つ</kun>
+			<on>イチ</on>
+			<kun>ひと-</kun>
+		</kanji>
+		<kanji>
+			<char>右</char>
+			<meaning>To the right</meaning>
+			<on>ユウ</on>
+			<on>ウ</on>
+			<kun>みぎ</kun>
+		</kanji>
+		<kanji>
+			<char>雨</char>
+			<meaning>Rain</meaning>
+			<kun>あめ</kun>
+			<on>ウ</on>
+			<kun>あま-</kun>
+		</kanji>
+		<kanji>
+			<char>円</char>
+			<meaning>Yen; Circular</meaning>
+			<kun>まろ・やか</kun>
+			<kun>まど・か</kun>
+			<kun>まる・い</kun>
+			<on>エン</on>
+			<kun>つぶ・ら</kun>
+			<kun>まど-</kun>
+			<kun>まる-</kun>
+		</kanji>
+		<kanji>
+			<char>王</char>
+			<meaning>Lord; Royalty</meaning>
+			<on>ノウ</on>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>音</char>
+			<meaning>Sound; Tone; Reading of Kanji</meaning>
+			<on>オン</on>
+			<kun>おと</kun>
+			<on>イン</on>
+			<on>ノン</on>
+			<kun>ね</kun>
+		</kanji>
+		<kanji>
+			<char>下</char>
+			<meaning>Go down; Lower; Under</meaning>
+			<on>ゲ</on>
+			<kun>しも</kun>
+			<kun>くだ・る</kun>
+			<kun>くだ・す</kun>
+			<kun>お・りる</kun>
+			<kun>さ・げる</kun>
+			<on>カ</on>
+			<kun>した</kun>
+			<kun>お・ろす</kun>
+			<kun>くだ・さる</kun>
+			<kun>もと</kun>
+			<kun>さ・がる</kun>
+		</kanji>
+		<kanji>
+			<char>火</char>
+			<meaning>Fire</meaning>
+			<kun>ひ</kun>
+			<on>カ</on>
+			<kun>ほ</kun>
+		</kanji>
+		<kanji>
+			<char>花</char>
+			<meaning>Flower; Become brilliant</meaning>
+			<on>ケ</on>
+			<on>カ</on>
+			<kun>はな</kun>
+			<kun>はな・やぐ</kun>
+		</kanji>
+		<kanji>
+			<char>貝</char>
+			<meaning>Shellfish</meaning>
+			<kun>かい</kun>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>学</char>
+			<meaning>Study; School; Science</meaning>
+			<kun>まな・ぶ</kun>
+			<on>ガク</on>
+		</kanji>
+		<kanji>
+			<char>気</char>
+			<meaning>Spirit; Mind; Chi</meaning>
+			<on>ケ</on>
+			<on>キ</on>
+			<kun>いき</kun>
+		</kanji>
+		<kanji>
+			<char>休</char>
+			<meaning>Rest; Holiday; Break</meaning>
+			<kun>やす・める</kun>
+			<on>キュウ</on>
+			<kun>やす・む</kun>
+			<kun>やす・まる</kun>
+		</kanji>
+		<kanji>
+			<char>玉</char>
+			<meaning>Ball; Jewel</meaning>
+			<kun>たま</kun>
+			<on>ギョク</on>
+		</kanji>
+		<kanji>
+			<char>金</char>
+			<meaning>Gold; Metal; Money</meaning>
+			<on>コン</on>
+			<kun>かな-</kun>
+			<on>キン</on>
+			<kun>かね</kun>
+		</kanji>
+		<kanji>
+			<char>九</char>
+			<meaning>Nine</meaning>
+			<on>ク</on>
+			<kun>ここの・つ</kun>
+			<on>キュウ</on>
+			<kun>ここの-</kun>
+		</kanji>
+		<kanji>
+			<char>空</char>
+			<meaning>Sky; Air; Empty</meaning>
+			<kun>から</kun>
+			<kun>あ・ける</kun>
+			<kun>す・く</kun>
+			<kun>むな・しい</kun>
+			<on>クウ</on>
+			<kun>そら</kun>
+			<kun>す・かす</kun>
+			<kun>あ・く</kun>
+			<kun>うつ・ろ</kun>
+		</kanji>
+		<kanji>
+			<char>月</char>
+			<meaning>Moon; Month</meaning>
+			<on>ガツ</on>
+			<on>ゲツ</on>
+			<kun>つき</kun>
+		</kanji>
+		<kanji>
+			<char>犬</char>
+			<meaning>Dog</meaning>
+			<kun>いぬ</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>見</char>
+			<meaning>See; Opinion</meaning>
+			<kun>み・える</kun>
+			<on>ケン</on>
+			<kun>み・る</kun>
+			<kun>み・せる</kun>
+		</kanji>
+		<kanji>
+			<char>五</char>
+			<meaning>Five</meaning>
+			<kun>いつ-</kun>
+			<on>ゴ</on>
+			<kun>いつ・つ</kun>
+		</kanji>
+		<kanji>
+			<char>口</char>
+			<meaning>Mouth; Opening</meaning>
+			<on>ク</on>
+			<on>コウ</on>
+			<kun>くち</kun>
+		</kanji>
+		<kanji>
+			<char>校</char>
+			<meaning>School; Proof</meaning>
+			<on>キョウ</on>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>左</char>
+			<meaning>To the left</meaning>
+			<kun>ひだり</kun>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>三</char>
+			<meaning>Three</meaning>
+			<kun>み-</kun>
+			<kun>み・つ</kun>
+			<on>サン</on>
+			<kun>み・つ</kun>
+		</kanji>
+		<kanji>
+			<char>山</char>
+			<meaning>Mountain; Great deal</meaning>
+			<kun>やま</kun>
+			<on>サン</on>
+		</kanji>
+		<kanji>
+			<char>四</char>
+			<meaning>Four</meaning>
+			<kun>よん</kun>
+			<kun>よ・つ</kun>
+			<on>シ</on>
+			<kun>よ-</kun>
+			<kun>よ・つ</kun>
+		</kanji>
+		<kanji>
+			<char>子</char>
+			<meaning>Child</meaning>
+			<on>ス</on>
+			<kun>ね</kun>
+			<on>シ</on>
+			<kun>こ</kun>
+		</kanji>
+		<kanji>
+			<char>糸</char>
+			<meaning>Thread</meaning>
+			<kun>いと</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>字</char>
+			<meaning>Character; Letter; Section of village</meaning>
+			<kun>あざ</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>耳</char>
+			<meaning>Ear; Hearing</meaning>
+			<kun>みみ</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>七</char>
+			<meaning>Seven</meaning>
+			<kun>なな</kun>
+			<kun>なな・つ</kun>
+			<on>シチ</on>
+			<kun>なの-</kun>
+		</kanji>
+		<kanji>
+			<char>車</char>
+			<meaning>Car; Vehicle; Wheel</meaning>
+			<kun>くるま</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>手</char>
+			<meaning>Hand</meaning>
+			<on>て</on>
+			<kun>シュ</kun>
+			<kun>た-</kun>
+		</kanji>
+		<kanji>
+			<char>十</char>
+			<meaning>Ten; Cross; Plenty</meaning>
+			<kun>ジ'</kun>
+			<kun>と-</kun>
+			<on>ジュウ</on>
+			<kun>ジュ'</kun>
+			<kun>とお</kun>
+		</kanji>
+		<kanji>
+			<char>出</char>
+			<meaning>Go out; Appear; Exit</meaning>
+			<kun>だ</kun>
+			<kun>い・だす</kun>
+			<kun>い・でる</kun>
+			<kun>で・る</kun>
+			<on>シュツ</on>
+			<kun>で</kun>
+			<kun>だ・す</kun>
+		</kanji>
+		<kanji>
+			<char>女</char>
+			<meaning>Woman; Female</meaning>
+			<on>ニョ</on>
+			<kun>おんあ</kun>
+			<on>ジョ</on>
+			<on>ニョウ</on>
+			<kun>め-</kun>
+		</kanji>
+		<kanji>
+			<char>小</char>
+			<meaning>Small; Little</meaning>
+			<kun>お</kun>
+			<kun>ちい・さい</kun>
+			<on>ショウ</on>
+			<kun>こ</kun>
+		</kanji>
+		<kanji>
+			<char>上</char>
+			<meaning>Rise; Up; Above</meaning>
+			<on>ショウ</on>
+			<kun>うえ</kun>
+			<kun>あ・がる</kun>
+			<kun>のぼ・る</kun>
+			<kun>かみ</kun>
+			<kun>のぼ・せる</kun>
+			<on>ジョウ</on>
+			<on>シャン</on>
+			<kun>あ・げる</kun>
+			<kun>のぼ・す</kun>
+			<kun>うわ-</kun>
+		</kanji>
+		<kanji>
+			<char>森</char>
+			<meaning>Forest</meaning>
+			<kun>もり</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>人</char>
+			<meaning>Person; Individual</meaning>
+			<on>ニン</on>
+			<kun>-と</kun>
+			<on>ジン</on>
+			<kun>ひと</kun>
+		</kanji>
+		<kanji>
+			<char>水</char>
+			<meaning>Water</meaning>
+			<kun>みず</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>正</char>
+			<meaning>Correct; Justice</meaning>
+			<on>ショウ</on>
+			<kun>まさ</kun>
+			<kun>ただ・す</kun>
+			<on>セイ</on>
+			<kun>ただ・しい</kun>
+			<kun>まさ・に</kun>
+		</kanji>
+		<kanji>
+			<char>生</char>
+			<meaning>Give birth; Live; Raw</meaning>
+			<kun>は・える</kun>
+			<kun>き</kun>
+			<kun>い・かす</kun>
+			<kun>う・む</kun>
+			<kun>は・やす</kun>
+			<kun>い・きる</kun>
+			<kun>お・う</kun>
+			<kun>む・す</kun>
+			<on>ショウ</on>
+			<kun>な・る</kun>
+			<kun>い・ける</kun>
+			<on>セイ</on>
+			<kun>な・す</kun>
+			<kun>う・まれる</kun>
+			<kun>なま</kun>
+		</kanji>
+		<kanji>
+			<char>青</char>
+			<meaning>Blue; Unripe; Turn pale</meaning>
+			<on>ショウ</on>
+			<kun>あお・い</kun>
+			<on>セイ</on>
+			<kun>あお</kun>
+		</kanji>
+		<kanji>
+			<char>石</char>
+			<meaning>Stone; Unit of volume</meaning>
+			<on>シャク</on>
+			<kun>いし</kun>
+			<on>セキ</on>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>赤</char>
+			<meaning>Red; Become red</meaning>
+			<on>シャク</on>
+			<kun>あか・い</kun>
+			<kun>あか・らめる</kun>
+			<on>セキ</on>
+			<kun>あか</kun>
+			<kun>あか・らむ</kun>
+		</kanji>
+		<kanji>
+			<char>先</char>
+			<meaning>Before; First of all; End</meaning>
+			<on>さき</on>
+			<on>セン</on>
+			<kun>ま・ず</kun>
+		</kanji>
+		<kanji>
+			<char>千</char>
+			<meaning>Thousand; Various</meaning>
+			<kun>ち</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>川</char>
+			<meaning>River</meaning>
+			<kun>かわ</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>早</char>
+			<meaning>Be early; Quick</meaning>
+			<kun>はや-</kun>
+			<kun>はや・める</kun>
+			<on>ソウ</on>
+			<kun>はや・まる</kun>
+			<kun>はや・い</kun>
+		</kanji>
+		<kanji>
+			<char>草</char>
+			<meaning>Grass; Brief; Draft</meaning>
+			<kun>くさ</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>足</char>
+			<meaning>Leg; Suffice; Add up</meaning>
+			<kun>あし</kun>
+			<kun>た・る</kun>
+			<kun>た・りる</kun>
+			<on>ソク</on>
+			<kun>た・す</kun>
+		</kanji>
+		<kanji>
+			<char>村</char>
+			<meaning>Village</meaning>
+			<kun>むら</kun>
+			<on>ソン</on>
+		</kanji>
+		<kanji>
+			<char>大</char>
+			<meaning>Large; Big</meaning>
+			<on>タイ</on>
+			<kun>おお・きい</kun>
+			<on>ダイ</on>
+			<kun>おお-</kun>
+			<kun>おお・いに</kun>
+		</kanji>
+		<kanji>
+			<char>男</char>
+			<meaning>Man; Male</meaning>
+			<on>ナン</on>
+			<kun>お</kun>
+			<on>ダン</on>
+			<kun>おとこ</kun>
+		</kanji>
+		<kanji>
+			<char>竹</char>
+			<meaning>Bamboo</meaning>
+			<kun>たけ</kun>
+			<on>チク</on>
+		</kanji>
+		<kanji>
+			<char>中</char>
+			<meaning>Middle; Inside; Throughout</meaning>
+			<kun>うち</kun>
+			<on>チュウ</on>
+			<kun>なか</kun>
+		</kanji>
+		<kanji>
+			<char>虫</char>
+			<meaning>Insect</meaning>
+			<kun>むし</kun>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>町</char>
+			<meaning>Town; Street</meaning>
+			<kun>まち</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>天</char>
+			<meaning>Heavens; Sky; Imperial</meaning>
+			<kun>あめ</kun>
+			<kun>あまつ</kun>
+			<on>テン</on>
+			<kun>あま-</kun>
+		</kanji>
+		<kanji>
+			<char>田</char>
+			<meaning>Paddy; Field</meaning>
+			<kun>た</kun>
+			<on>デン</on>
+		</kanji>
+		<kanji>
+			<char>土</char>
+			<meaning>Soil; Earth; Land</meaning>
+			<on>ト</on>
+			<on>ド</on>
+			<kun>つち</kun>
+		</kanji>
+		<kanji>
+			<char>二</char>
+			<meaning>Two</meaning>
+			<on>ジ</on>
+			<kun>ふた・つ</kun>
+			<on>ニ</on>
+			<kun>ふた-</kun>
+		</kanji>
+		<kanji>
+			<char>日</char>
+			<meaning>Day; Sun; Japan</meaning>
+			<on>ジツ</on>
+			<kun>-か</kun>
+			<on>ニチ</on>
+			<kun>ひ</kun>
+		</kanji>
+		<kanji>
+			<char>入</char>
+			<meaning>Enter; Insert</meaning>
+			<kun>い・れる</kun>
+			<on>ニュウ</on>
+			<kun>い・る</kun>
+			<kun>はい・る</kun>
+		</kanji>
+		<kanji>
+			<char>年</char>
+			<meaning>Year; Age</meaning>
+			<kun>とし</kun>
+			<on>ネン</on>
+		</kanji>
+		<kanji>
+			<char>白</char>
+			<meaning>White; Become light</meaning>
+			<on>ビャク</on>
+			<kun>しら-</kun>
+			<kun>しら・ける</kun>
+			<on>ハク</on>
+			<kun>しろ</kun>
+			<kun>しら・む</kun>
+			<kun>しろ・い</kun>
+		</kanji>
+		<kanji>
+			<char>八</char>
+			<meaning>Eight</meaning>
+			<kun>や-</kun>
+			<kun>や・つ</kun>
+			<on>ハチ</on>
+			<kun>や・つ</kun>
+		</kanji>
+		<kanji>
+			<char>百</char>
+			<meaning>Hundred; Many</meaning>
+			<kun>もも</kun>
+			<on>ヒャク</on>
+		</kanji>
+		<kanji>
+			<char>文</char>
+			<meaning>Culture; Literature; Sentence</meaning>
+			<on>モン</on>
+			<on>ブン</on>
+			<kun>あや</kun>
+		</kanji>
+		<kanji>
+			<char>本</char>
+			<meaning>Book; Base; Origin</meaning>
+			<kun>もと</kun>
+			<on>ホン</on>
+		</kanji>
+		<kanji>
+			<char>名</char>
+			<meaning>Name; Famous</meaning>
+			<on>ミョウ</on>
+			<on>メイ</on>
+			<kun>な</kun>
+		</kanji>
+		<kanji>
+			<char>木</char>
+			<meaning>Tree; Wood</meaning>
+			<on>モク</on>
+			<kun>こ-</kun>
+			<on>ボク</on>
+			<kun>き</kun>
+		</kanji>
+		<kanji>
+			<char>目</char>
+			<meaning>Eye; -Th</meaning>
+			<on>ボク</on>
+			<kun>ま</kun>
+			<on>モク</on>
+			<kun>め</kun>
+		</kanji>
+		<kanji>
+			<char>夕</char>
+			<meaning>Evening</meaning>
+			<kun>ゆう</kun>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>立</char>
+			<meaning>Stand up; Principle</meaning>
+			<kun>た・てる</kun>
+			<on>リツ</on>
+			<kun>た・つ</kun>
+		</kanji>
+		<kanji>
+			<char>力</char>
+			<meaning>Exert; Power; Strength</meaning>
+			<kun>リキ</kun>
+			<kun>りき・む</kun>
+			<on>リョク</on>
+			<kun>ちから</kun>
+		</kanji>
+		<kanji>
+			<char>林</char>
+			<meaning>Woods; Grove</meaning>
+			<on>はやし</on>
+			<kun>リン</kun>
+		</kanji>
+		<kanji>
+			<char>六</char>
+			<meaning>Six</meaning>
+			<on>リク</on>
+			<kun>むい-</kun>
+			<kun>む・つ</kun>
+			<on>ロク</on>
+			<kun>む</kun>
+			<kun>む・つ</kun>
+		</kanji>
+	</category>
+	<category id="kanji_2">
+		<kanji>
+			<char>引</char>
+			<meaning>Pull; Attract; Subtract</meaning>
+			<kun>ひ・く</kun>
+			<on>イン</on>
+			<kun>ひ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>羽</char>
+			<meaning>Wing; Feather</meaning>
+			<kun>は</kun>
+			<kun>-わ</kun>
+			<on>ウ</on>
+			<kun>はね</kun>
+		</kanji>
+		<kanji>
+			<char>雲</char>
+			<meaning>Cloud</meaning>
+			<kun>くも</kun>
+			<on>ウン</on>
+		</kanji>
+		<kanji>
+			<char>園</char>
+			<meaning>Garden; Park</meaning>
+			<kun>その</kun>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>遠</char>
+			<meaning>Far; Distant</meaning>
+			<on>オン</on>
+			<on>エン</on>
+			<kun>とお・い</kun>
+		</kanji>
+		<kanji>
+			<char>黄</char>
+			<meaning>Yellow</meaning>
+			<on>オウ</on>
+			<kun>こ</kun>
+			<on>コウ</on>
+			<kun>き</kun>
+		</kanji>
+		<kanji>
+			<char>何</char>
+			<meaning>What</meaning>
+			<kun>なに</kun>
+			<on>カ</on>
+			<kun>なん</kun>
+		</kanji>
+		<kanji>
+			<char>夏</char>
+			<meaning>Summer</meaning>
+			<on>ガ</on>
+			<kun>なつ</kun>
+			<on>カ</on>
+			<on>ゲ</on>
+		</kanji>
+		<kanji>
+			<char>家</char>
+			<meaning>House; Family</meaning>
+			<on>ケ</on>
+			<kun>や</kun>
+			<on>カ</on>
+			<kun>いえ</kun>
+			<kun>うち</kun>
+		</kanji>
+		<kanji>
+			<char>科</char>
+			<meaning>Section; Department; Course</meaning>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>歌</char>
+			<meaning>Sing; Song; Poetry</meaning>
+			<kun>うた</kun>
+			<on>カ</on>
+			<kun>うた・う</kun>
+		</kanji>
+		<kanji>
+			<char>画</char>
+			<meaning>Brush stroke; Picture</meaning>
+			<on>エ</on>
+			<kun>えが・く</kun>
+			<on>ガ</on>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>会</char>
+			<meaning>Meet; Society; Association</meaning>
+			<on>エ</on>
+			<on>カイ</on>
+			<kun>あ・う</kun>
+		</kanji>
+		<kanji>
+			<char>回</char>
+			<meaning>Turn; Spin; Occurrence</meaning>
+			<on>エ</on>
+			<kun>まわ・す</kun>
+			<on>カイ</on>
+			<kun>まわ・る</kun>
+			<kun>もとお・る</kun>
+		</kanji>
+		<kanji>
+			<char>海</char>
+			<meaning>Sea; Ocean</meaning>
+			<kun>うみ</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>絵</char>
+			<meaning>Picture; Painting</meaning>
+			<on>エ</on>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>外</char>
+			<meaning>Remove; Outside; Foreign</meaning>
+			<on>ゲ</on>
+			<kun>ほか</kun>
+			<kun>はず・れる</kun>
+			<on>ガイ</on>
+			<kun>そと</kun>
+			<kun>はず・す</kun>
+		</kanji>
+		<kanji>
+			<char>角</char>
+			<meaning>Corner; Angle; Horn</meaning>
+			<kun>かど</kun>
+			<on>カク</on>
+			<kun>つの</kun>
+		</kanji>
+		<kanji>
+			<char>楽</char>
+			<meaning>Have fun; Music; Pleasure</meaning>
+			<on>ラク</on>
+			<kun>たの・しむ</kun>
+			<on>ガク</on>
+			<kun>たの・しい</kun>
+		</kanji>
+		<kanji>
+			<char>活</char>
+			<meaning>Resuscitate; Arrange flowers; Daily life</meaning>
+			<kun>い・きる</kun>
+			<kun>い・かす</kun>
+			<on>カツ</on>
+			<kun>い・ける</kun>
+		</kanji>
+		<kanji>
+			<char>間</char>
+			<meaning>Room; Interval; Period of time</meaning>
+			<on>ケン</on>
+			<kun>ま</kun>
+			<on>カン</on>
+			<kun>あいだ</kun>
+			<kun>あい</kun>
+		</kanji>
+		<kanji>
+			<char>丸</char>
+			<meaning>Make round; Circular; Spherical</meaning>
+			<kun>まる</kun>
+			<kun>まる・める</kun>
+			<on>ガン</on>
+			<kun>まる・い</kun>
+			<kun>まる・まる</kun>
+		</kanji>
+		<kanji>
+			<char>岩</char>
+			<meaning>Rock; Cliff</meaning>
+			<kun>いわ</kun>
+			<on>ガン</on>
+		</kanji>
+		<kanji>
+			<char>顔</char>
+			<meaning>Face; Features</meaning>
+			<kun>かお</kun>
+			<on>ガン</on>
+		</kanji>
+		<kanji>
+			<char>帰</char>
+			<meaning>Return; Go home</meaning>
+			<kun>か・える</kun>
+			<on>キ</on>
+			<kun>か・えす</kun>
+		</kanji>
+		<kanji>
+			<char>汽</char>
+			<meaning>Steam</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>記</char>
+			<meaning>Record; Chronicle</meaning>
+			<kun>しる・す</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>弓</char>
+			<meaning>Bow; Crescent shaped</meaning>
+			<kun>ゆみ</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>牛</char>
+			<meaning>Cow; Ox</meaning>
+			<kun>うし</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>魚</char>
+			<meaning>Fish</meaning>
+			<kun>うお</kun>
+			<on>ギョ</on>
+			<kun>さかな</kun>
+		</kanji>
+		<kanji>
+			<char>京</char>
+			<meaning>Capital; Metropolis; 10^16</meaning>
+			<on>ケイ</on>
+			<kun>みやこ</kun>
+			<on>キョウ</on>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>強</char>
+			<meaning>Strengthen; Compel; Strong</meaning>
+			<on>ゴウ</on>
+			<kun>し・いる</kun>
+			<kun>つよ・まる</kun>
+			<on>キョウ</on>
+			<kun>つよ・い</kun>
+			<kun>つよ・める</kun>
+		</kanji>
+		<kanji>
+			<char>教</char>
+			<meaning>Teach; Education; Doctrine</meaning>
+			<kun>おそ・わる</kun>
+			<on>キュウ</on>
+			<kun>おし・える</kun>
+		</kanji>
+		<kanji>
+			<char>近</char>
+			<meaning>Nearby; Close</meaning>
+			<on>コン</on>
+			<kun>ちか・い</kun>
+			<on>キン</on>
+			<kun>ちか-</kun>
+		</kanji>
+		<kanji>
+			<char>兄</char>
+			<meaning>Older brother</meaning>
+			<on>キョウ</on>
+			<on>ケイ</on>
+			<kun>あに</kun>
+		</kanji>
+		<kanji>
+			<char>形</char>
+			<meaning>Figure; Shape; Style</meaning>
+			<on>ギョウ</on>
+			<kun>かた</kun>
+			<on>ケイ</on>
+			<kun>かたち</kun>
+			<kun>なり</kun>
+		</kanji>
+		<kanji>
+			<char>計</char>
+			<meaning>Measure; Plan; Meter</meaning>
+			<kun>はか・る</kun>
+			<on>ケイ</on>
+			<kun>はか・らう</kun>
+		</kanji>
+		<kanji>
+			<char>元</char>
+			<meaning>Origin; Source; Formerly</meaning>
+			<on>ガン</on>
+			<on>ゲン</on>
+			<kun>もと</kun>
+		</kanji>
+		<kanji>
+			<char>原</char>
+			<meaning>Field; Cause; Original</meaning>
+			<kun>はら</kun>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>言</char>
+			<meaning>Say; Word; Utterance</meaning>
+			<on>ゴン</on>
+			<kun>い・う</kun>
+			<on>ゲン</on>
+			<kun>こと</kun>
+		</kanji>
+		<kanji>
+			<char>古</char>
+			<meaning>Wear out; Old; Ancient times</meaning>
+			<kun>いにしえ</kun>
+			<kun>ふる・い</kun>
+			<kun>ふる・びる</kun>
+			<on>コ</on>
+			<kun>ふる-</kun>
+			<kun>ふる・す</kun>
+		</kanji>
+		<kanji>
+			<char>戸</char>
+			<meaning>Door</meaning>
+			<kun>と</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>午</char>
+			<meaning>Noon</meaning>
+			<on>ゴ</on>
+		</kanji>
+		<kanji>
+			<char>後</char>
+			<meaning>Be late; After; Behind</meaning>
+			<on>コウ</on>
+			<kun>のち</kun>
+			<kun>おく・れる</kun>
+			<on>ゴ</on>
+			<kun>あと</kun>
+			<kun>うし・ろ</kun>
+		</kanji>
+		<kanji>
+			<char>語</char>
+			<meaning>Talk; Word; Language</meaning>
+			<kun>かた・る</kun>
+			<on>ゴ</on>
+			<kun>かた・らう</kun>
+		</kanji>
+		<kanji>
+			<char>交</char>
+			<meaning>Mix; Converse; Evade</meaning>
+			<kun>まじ・える</kun>
+			<kun>まじ・る</kun>
+			<kun>か・わす</kun>
+			<kun>こも</kun>
+			<kun>まじ・わる</kun>
+			<on>コウ</on>
+			<kun>ま・ぜる</kun>
+			<kun>-か・う</kun>
+			<kun>こもごも</kun>
+			<kun>ま・ざる</kun>
+		</kanji>
+		<kanji>
+			<char>光</char>
+			<meaning>Illuminate; Light</meaning>
+			<kun>ひかり</kun>
+			<on>コウ</on>
+			<kun>ひか・る</kun>
+		</kanji>
+		<kanji>
+			<char>公</char>
+			<meaning>Official; Public; Prince</meaning>
+			<on>ク</on>
+			<on>コウ</on>
+			<kun>おおやけ</kun>
+		</kanji>
+		<kanji>
+			<char>工</char>
+			<meaning>Manufacturing; Construction</meaning>
+			<on>ク</on>
+			<on>コウ</on>
+			<on>たくみ</on>
+		</kanji>
+		<kanji>
+			<char>広</char>
+			<meaning>Spread; Widen; Broad</meaning>
+			<kun>ひろ・い</kun>
+			<kun>ひろ・まる</kun>
+			<kun>ひろ・がる</kun>
+			<on>コウ</on>
+			<kun>ひろ・める</kun>
+			<kun>ひろ・げる</kun>
+		</kanji>
+		<kanji>
+			<char>考</char>
+			<meaning>Think; Consider; Thought</meaning>
+			<kun>かんが・え</kun>
+			<on>コウ</on>
+			<kun>かんが・える</kun>
+		</kanji>
+		<kanji>
+			<char>行</char>
+			<meaning>Go; Conduct; Travel</meaning>
+			<on>アン</on>
+			<kun>い・く</kun>
+			<kun>おこな・う</kun>
+			<on>コウ</on>
+			<on>ギョウ</on>
+			<kun>い・ける</kun>
+			<kun>ゆ・く</kun>
+		</kanji>
+		<kanji>
+			<char>高</char>
+			<meaning>Lift; Tall; Quantity</meaning>
+			<kun>たか・い</kun>
+			<kun>たか・める</kun>
+			<on>コウ</on>
+			<kun>たか-</kun>
+			<kun>たか・まる</kun>
+		</kanji>
+		<kanji>
+			<char>合</char>
+			<meaning>Be suitable; Fit; Unify</meaning>
+			<kun>ガ'</kun>
+			<kun>あい</kun>
+			<kun>あ・わす</kun>
+			<on>ゴウ</on>
+			<kun>カ'</kun>
+			<kun>あ・わせる</kun>
+			<kun>あ・う</kun>
+		</kanji>
+		<kanji>
+			<char>国</char>
+			<meaning>Country; Nation</meaning>
+			<kun>くに</kun>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>黒</char>
+			<meaning>Blacken; Black</meaning>
+			<kun>くろ</kun>
+			<kun>くろ・らか</kun>
+			<kun>くろ・ずむ</kun>
+			<on>コク</on>
+			<kun>くろ・い</kun>
+			<kun>くろ・める</kun>
+		</kanji>
+		<kanji>
+			<char>今</char>
+			<meaning>Now; The present</meaning>
+			<on>コン</on>
+			<on>キン</on>
+			<kun>いま</kun>
+		</kanji>
+		<kanji>
+			<char>才</char>
+			<meaning>Ability; Genius; Years old</meaning>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>細</char>
+			<meaning>Become thin; Slender; Detailed</meaning>
+			<kun>ほそ・い</kun>
+			<kun>こま・かな</kun>
+			<kun>ほそ・る</kun>
+			<kun>ほそ・める</kun>
+			<on>サイ</on>
+			<kun>こま・かい</kun>
+			<kun>こま・やか</kun>
+		</kanji>
+		<kanji>
+			<char>作</char>
+			<meaning>Create; Produce; A harvest</meaning>
+			<on>サ</on>
+			<on>サク</on>
+			<kun>つく・る</kun>
+		</kanji>
+		<kanji>
+			<char>算</char>
+			<meaning>Calculation; Arithmetic</meaning>
+			<kun>そろ</kun>
+			<on>サン</on>
+		</kanji>
+		<kanji>
+			<char>姉</char>
+			<meaning>Older sister</meaning>
+			<kun>あね</kun>
+			<on>シ</on>
+			<kun>ねえ</kun>
+		</kanji>
+		<kanji>
+			<char>市</char>
+			<meaning>Market; City</meaning>
+			<kun>いち</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>思</char>
+			<meaning>Think; Consider; Thought</meaning>
+			<kun>おも・い</kun>
+			<kun>おぼ・す</kun>
+			<on>シ</on>
+			<kun>おも・う</kun>
+		</kanji>
+		<kanji>
+			<char>止</char>
+			<meaning>Stop; Cease</meaning>
+			<kun>と・める</kun>
+			<kun>とど・める</kun>
+			<kun>よ・す</kun>
+			<kun>や・む</kun>
+			<on>シ</on>
+			<kun>と・まる</kun>
+			<kun>や・める</kun>
+			<kun>とど・まる</kun>
+		</kanji>
+		<kanji>
+			<char>紙</char>
+			<meaning>Paper</meaning>
+			<kun>かみ</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>寺</char>
+			<meaning>Temple</meaning>
+			<kun>てら</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>時</char>
+			<meaning>Time; Occasion; O'clock</meaning>
+			<kun>とき</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>自</char>
+			<meaning>Self; One's own</meaning>
+			<on>シ</on>
+			<kun>おの・ずから</kun>
+			<on>ジ</on>
+			<kun>みずか・ら</kun>
+		</kanji>
+		<kanji>
+			<char>室</char>
+			<meaning>Room; Cellar; Greenhouse</meaning>
+			<kun>むろ</kun>
+			<on>シツ</on>
+		</kanji>
+		<kanji>
+			<char>社</char>
+			<meaning>Company; Association; Shrine</meaning>
+			<kun>やしろ</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>弱</char>
+			<meaning>Weaken; Feeble</meaning>
+			<kun>よわ・める</kun>
+			<kun>よわ・る</kun>
+			<on>ジャク</on>
+			<kun>よわ・い</kun>
+			<kun>よわ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>首</char>
+			<meaning>Neck; Leader</meaning>
+			<kun>くび</kun>
+			<on>シュ</on>
+		</kanji>
+		<kanji>
+			<char>秋</char>
+			<meaning>Autumn</meaning>
+			<kun>あき</kun>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>週</char>
+			<meaning>Week</meaning>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>春</char>
+			<meaning>Springtime; Adolescence</meaning>
+			<kun>はる</kun>
+			<on>シュン</on>
+		</kanji>
+		<kanji>
+			<char>書</char>
+			<meaning>Write; Book; Message</meaning>
+			<kun>か・く</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>少</char>
+			<meaning>A little; Few</meaning>
+			<kun>すこ・し</kun>
+			<on>ショウ</on>
+			<kun>すく・ない</kun>
+		</kanji>
+		<kanji>
+			<char>場</char>
+			<meaning>Place; Stage</meaning>
+			<kun>ば</kun>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>色</char>
+			<meaning>Colour; Various</meaning>
+			<on>シキ</on>
+			<on>ショク</on>
+			<kun>いろ</kun>
+		</kanji>
+		<kanji>
+			<char>食</char>
+			<meaning>Eat; Feed; Food</meaning>
+			<on>ジキ</on>
+			<kun>く・らう</kun>
+			<on>ショク</on>
+			<kun>く・う</kun>
+			<kun>た・べる</kun>
+		</kanji>
+		<kanji>
+			<char>心</char>
+			<meaning>Heart; Spirit; Core</meaning>
+			<kun>こころ</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>新</char>
+			<meaning>New; Novel</meaning>
+			<kun>あたら・しい</kun>
+			<kun>にい-</kun>
+			<on>シン</on>
+			<kun>あら・た</kun>
+		</kanji>
+		<kanji>
+			<char>親</char>
+			<meaning>Be intimate; Make friends; Parent</meaning>
+			<kun>おや</kun>
+			<kun>した・しむ</kun>
+			<on>シン</on>
+			<kun>した・しい</kun>
+		</kanji>
+		<kanji>
+			<char>図</char>
+			<meaning>Design; Plot; Diagram</meaning>
+			<kun>はか・る</kun>
+			<on>ズ</on>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>数</char>
+			<meaning>Number; Side dish</meaning>
+			<kun>かず</kun>
+			<on>スウ</on>
+			<on>ス</on>
+		</kanji>
+		<kanji>
+			<char>星</char>
+			<meaning>Star; Planet</meaning>
+			<on>ショウ</on>
+			<on>セイ</on>
+			<kun>ほし</kun>
+		</kanji>
+		<kanji>
+			<char>晴</char>
+			<meaning>Be clear; Dispel doubts; Good weather</meaning>
+			<kun>は・れる</kun>
+			<on>セイ</on>
+			<kun>は・らす</kun>
+		</kanji>
+		<kanji>
+			<char>声</char>
+			<meaning>Voice; Cry</meaning>
+			<on>ショウ</on>
+			<kun>こわ-</kun>
+			<on>セイ</on>
+			<kun>こえ</kun>
+		</kanji>
+		<kanji>
+			<char>西</char>
+			<meaning>West</meaning>
+			<on>サイ</on>
+			<on>セイ</on>
+			<kun>にし</kun>
+		</kanji>
+		<kanji>
+			<char>切</char>
+			<meaning>Cut off; Be sharp; Eager</meaning>
+			<on>サイ</on>
+			<kun>き・れる</kun>
+			<on>セツ</on>
+			<kun>き・る</kun>
+		</kanji>
+		<kanji>
+			<char>雪</char>
+			<meaning>Snow</meaning>
+			<kun>ゆき</kun>
+			<on>セツ</on>
+		</kanji>
+		<kanji>
+			<char>線</char>
+			<meaning>Line; Circuit; Beam</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>船</char>
+			<meaning>Ship; Boat; Vessel</meaning>
+			<kun>ふね</kun>
+			<on>セン</on>
+			<kun>ふな-</kun>
+		</kanji>
+		<kanji>
+			<char>前</char>
+			<meaning>Before; The above; You</meaning>
+			<kun>まえ</kun>
+			<on>ゼン</on>
+		</kanji>
+		<kanji>
+			<char>組</char>
+			<meaning>Assemble; Association; Team</meaning>
+			<kun>くみ</kun>
+			<on>ソ</on>
+			<kun>く・む</kun>
+		</kanji>
+		<kanji>
+			<char>走</char>
+			<meaning>Run</meaning>
+			<kun>はし・る</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>多</char>
+			<meaning>Many; Multi-</meaning>
+			<kun>おお・い</kun>
+			<kun>まさ・る</kun>
+			<on>タ</on>
+			<kun>まさ・に</kun>
+		</kanji>
+		<kanji>
+			<char>太</char>
+			<meaning>Fatten; Plump</meaning>
+			<on>タ</on>
+			<kun>ふと・る</kun>
+			<on>タイ</on>
+			<kun>ふと・い</kun>
+		</kanji>
+		<kanji>
+			<char>体</char>
+			<meaning>Body; Form; Substance</meaning>
+			<on>テイ</on>
+			<on>タイ</on>
+			<kun>からだ</kun>
+		</kanji>
+		<kanji>
+			<char>台</char>
+			<meaning>Pedestal; Stand</meaning>
+			<on>タイ</on>
+			<on>ダイ</on>
+		</kanji>
+		<kanji>
+			<char>谷</char>
+			<meaning>Valley; Ravine; Lowlands</meaning>
+			<kun>さこ</kun>
+			<kun>-や</kun>
+			<kun>やと</kun>
+			<on>コク</on>
+			<kun>たに</kun>
+			<kun>やち</kun>
+		</kanji>
+		<kanji>
+			<char>知</char>
+			<meaning>Know; Inform; Intelligence</meaning>
+			<kun>し・る</kun>
+			<on>チ</on>
+			<kun>し・らせる</kun>
+		</kanji>
+		<kanji>
+			<char>地</char>
+			<meaning>Land; Region; Cloth</meaning>
+			<on>ジ</on>
+			<on>チ</on>
+		</kanji>
+		<kanji>
+			<char>池</char>
+			<meaning>Pond; Pool; Reservoir</meaning>
+			<kun>いけ</kun>
+			<on>チ</on>
+		</kanji>
+		<kanji>
+			<char>茶</char>
+			<meaning>Tea</meaning>
+			<on>サ</on>
+			<on>チャ</on>
+		</kanji>
+		<kanji>
+			<char>昼</char>
+			<meaning>Noon; Daytime</meaning>
+			<kun>ひる</kun>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>朝</char>
+			<meaning>Morning; Dynasty</meaning>
+			<kun>あさ</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>長</char>
+			<meaning>Long; Chief; Master</meaning>
+			<kun>なが・い</kun>
+			<on>チョウ</on>
+			<kun>おさ</kun>
+		</kanji>
+		<kanji>
+			<char>鳥</char>
+			<meaning>Bird; Chicken</meaning>
+			<kun>とり</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>直</char>
+			<meaning>Direct; Ordinary; Immediate</meaning>
+			<on>ジキ</on>
+			<kun>す・ぐ</kun>
+			<kun>なお・き</kun>
+			<kun>なお・る</kun>
+			<on>チョク</on>
+			<on>じか・に</on>
+			<kun>なお・す</kun>
+			<kun>ただ・ちに</kun>
+		</kanji>
+		<kanji>
+			<char>通</char>
+			<meaning>Pass through; Commute; Traffic</meaning>
+			<on>ツ</on>
+			<kun>かよ・う</kun>
+			<kun>とお・す</kun>
+			<on>ツウ</on>
+			<kun>とお・り</kun>
+			<kun>とお・る</kun>
+		</kanji>
+		<kanji>
+			<char>弟</char>
+			<meaning>Younger brother; Pupil</meaning>
+			<on>テイ</on>
+			<kun>おとうと</kun>
+			<on>ダイ</on>
+			<on>デ</on>
+		</kanji>
+		<kanji>
+			<char>店</char>
+			<meaning>Shop; Store; Stock</meaning>
+			<kun>みせ</kun>
+			<on>テン</on>
+			<kun>たな</kun>
+		</kanji>
+		<kanji>
+			<char>点</char>
+			<meaning>Catch fire; Turn on; Spot</meaning>
+			<kun>さ・す</kun>
+			<kun>とぼ・す</kun>
+			<kun>つ・ける</kun>
+			<kun>とも・す</kun>
+			<on>テン</on>
+			<kun>とぼ・る</kun>
+			<kun>つ・く</kun>
+			<kun>とも・る</kun>
+		</kanji>
+		<kanji>
+			<char>電</char>
+			<meaning>Electricity</meaning>
+			<on>デン</on>
+		</kanji>
+		<kanji>
+			<char>冬</char>
+			<meaning>Winter</meaning>
+			<kun>ふゆ</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>刀</char>
+			<meaning>Katana; Blade; Sword</meaning>
+			<kun>かたな</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>東</char>
+			<meaning>East</meaning>
+			<kun>ひがし</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>当</char>
+			<meaning>Hit; Guess correctly; Allowance</meaning>
+			<kun>あ・たり</kun>
+			<kun>あ・たる</kun>
+			<on>トウ</on>
+			<kun>あ・て</kun>
+			<kun>あ・てる</kun>
+		</kanji>
+		<kanji>
+			<char>答</char>
+			<meaning>Reply; Answer</meaning>
+			<kun>こた・える</kun>
+			<on>トウ</on>
+			<kun>こた・え</kun>
+		</kanji>
+		<kanji>
+			<char>頭</char>
+			<meaning>Head; Leader</meaning>
+			<on>ズ</on>
+			<kun>あたま</kun>
+			<on>トウ</on>
+			<on>ト</on>
+			<kun>かしら</kun>
+		</kanji>
+		<kanji>
+			<char>同</char>
+			<meaning>Same as; Agree; Equal</meaning>
+			<kun>おな・じ</kun>
+			<kun>どう・ずる</kun>
+			<on>ドウ</on>
+			<kun>どう・じる</kun>
+		</kanji>
+		<kanji>
+			<char>道</char>
+			<meaning>Road; Street; Philosophical way</meaning>
+			<on>トウ</on>
+			<on>ドウ</on>
+			<kun>みち</kun>
+		</kanji>
+		<kanji>
+			<char>読</char>
+			<meaning>Read; Peruse</meaning>
+			<on>トク</on>
+			<kun>よ・む</kun>
+			<on>ドク</on>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>内</char>
+			<meaning>Inside; WIthin; Home</meaning>
+			<on>ダイ</on>
+			<on>ナイ</on>
+			<kun>うち</kun>
+		</kanji>
+		<kanji>
+			<char>南</char>
+			<meaning>South</meaning>
+			<on>ナ</on>
+			<on>ナン</on>
+			<kun>みなみ</kun>
+		</kanji>
+		<kanji>
+			<char>肉</char>
+			<meaning>Meat; Flesh</meaning>
+			<on>ニク</on>
+		</kanji>
+		<kanji>
+			<char>馬</char>
+			<meaning>Horse</meaning>
+			<kun>うま</kun>
+			<on>バ</on>
+			<kun>-ま</kun>
+		</kanji>
+		<kanji>
+			<char>買</char>
+			<meaning>Buy; Purchase</meaning>
+			<kun>か・う</kun>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>売</char>
+			<meaning>Sell; Retail</meaning>
+			<kun>う・る</kun>
+			<on>バイ</on>
+			<kun>う・れる</kun>
+		</kanji>
+		<kanji>
+			<char>麦</char>
+			<meaning>Barley; Wheat</meaning>
+			<kun>むぎ</kun>
+			<on>バク</on>
+		</kanji>
+		<kanji>
+			<char>半</char>
+			<meaning>Half; Middle</meaning>
+			<kun>なか・ば</kun>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>番</char>
+			<meaning>Number; Ranking; Guard</meaning>
+			<on>バン</on>
+		</kanji>
+		<kanji>
+			<char>父</char>
+			<meaning>Father</meaning>
+			<kun>ちち</kun>
+			<on>フ</on>
+			<on>とう・さん</on>
+		</kanji>
+		<kanji>
+			<char>風</char>
+			<meaning>Wind; Style</meaning>
+			<on>フ</on>
+			<kun>かざ</kun>
+			<on>フウ</on>
+			<kun>かぜ</kun>
+		</kanji>
+		<kanji>
+			<char>分</char>
+			<meaning>Divide; Section; A minute</meaning>
+			<on>フン</on>
+			<kun>わ・ける</kun>
+			<kun>わ・かる</kun>
+			<on>ブン</on>
+			<on>ブ</on>
+			<kun>わ・かつ</kun>
+			<kun>わ・け</kun>
+		</kanji>
+		<kanji>
+			<char>聞</char>
+			<meaning>Hear; Ask; Inform</meaning>
+			<on>モン</on>
+			<kun>き・こえる</kun>
+			<on>ブン</on>
+			<kun>き・く</kun>
+		</kanji>
+		<kanji>
+			<char>米</char>
+			<meaning>Rice; America</meaning>
+			<on>マイ</on>
+			<on>ベイ</on>
+			<kun>こめ</kun>
+		</kanji>
+		<kanji>
+			<char>歩</char>
+			<meaning>Walk; Step; Stride</meaning>
+			<on>フ</on>
+			<kun>ある・く</kun>
+			<on>ホ</on>
+			<on>ブ</on>
+			<kun>あゆ・む</kun>
+		</kanji>
+		<kanji>
+			<char>母</char>
+			<meaning>Mother</meaning>
+			<kun>はは</kun>
+			<on>バ</on>
+			<on>ボ</on>
+			<on>かあ・さん</on>
+		</kanji>
+		<kanji>
+			<char>方</char>
+			<meaning>Direction; Style; Personage</meaning>
+			<kun>かた</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>北</char>
+			<meaning>North</meaning>
+			<kun>きた</kun>
+			<on>ホク</on>
+		</kanji>
+		<kanji>
+			<char>妹</char>
+			<meaning>Younger sister</meaning>
+			<kun>いもうと</kun>
+			<on>マイ</on>
+		</kanji>
+		<kanji>
+			<char>毎</char>
+			<meaning>Every; Each</meaning>
+			<kun>-ごと</kun>
+			<on>マイ</on>
+		</kanji>
+		<kanji>
+			<char>万</char>
+			<meaning>Ten thousand; Many; Myriad</meaning>
+			<on>バン</on>
+			<on>マン</on>
+			<kun>よろず</kun>
+		</kanji>
+		<kanji>
+			<char>明</char>
+			<meaning>Become light; Obvious; Dawn</meaning>
+			<on>ミョウ</on>
+			<kun>あ・かり</kun>
+			<kun>あか・らむ</kun>
+			<kun>あか・るむ</kun>
+			<kun>あき・らか</kun>
+			<kun>あ・かす</kun>
+			<on>メイ</on>
+			<on>ミン</on>
+			<kun>あ・く</kun>
+			<kun>あ・ける</kun>
+			<kun>あか・るい</kun>
+			<kun>あ・くる</kun>
+		</kanji>
+		<kanji>
+			<char>鳴</char>
+			<meaning>Resound; Cry out; Chime</meaning>
+			<kun>な・く</kun>
+			<kun>な・らす</kun>
+			<on>メイ</on>
+			<kun>な・る</kun>
+		</kanji>
+		<kanji>
+			<char>毛</char>
+			<meaning>Hair; Fur; Down</meaning>
+			<kun>け</kun>
+			<on>モウ</on>
+		</kanji>
+		<kanji>
+			<char>門</char>
+			<meaning>Gates</meaning>
+			<kun>かど</kun>
+			<on>モン</on>
+			<kun>と</kun>
+		</kanji>
+		<kanji>
+			<char>夜</char>
+			<meaning>Evening; Night</meaning>
+			<kun>よる</kun>
+			<on>ヤ</on>
+			<kun>よ-</kun>
+		</kanji>
+		<kanji>
+			<char>野</char>
+			<meaning>Field; Wilds</meaning>
+			<kun>の</kun>
+			<on>ヤ</on>
+		</kanji>
+		<kanji>
+			<char>矢</char>
+			<meaning>Arrow</meaning>
+			<kun>や</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>友</char>
+			<meaning>Companion; Friend</meaning>
+			<kun>とも</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>曜</char>
+			<meaning>Day of week</meaning>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>用</char>
+			<meaning>Employ; Make use; Business</meaning>
+			<kun>もち・いる</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>来</char>
+			<meaning>Come; Arrive</meaning>
+			<kun>く・る</kun>
+			<kun>き・たす</kun>
+			<on>ライ</on>
+			<kun>き・たる</kun>
+		</kanji>
+		<kanji>
+			<char>理</char>
+			<meaning>Reason; Cause; Logic</meaning>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>里</char>
+			<meaning>Village; Unit of distance</meaning>
+			<kun>さと</kun>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>話</char>
+			<meaning>Talk; Tale; Story</meaning>
+			<kun>はなし</kun>
+			<on>ワ</on>
+			<kun>はな・す</kun>
+		</kanji>
+	</category>
+	<category id="kanji_3">
+		<kanji>
+			<char>悪</char>
+			<meaning>Bad; Evil; Hateful</meaning>
+			<on>オ</on>
+			<kun>わる</kun>
+			<kun>あ・し</kun>
+			<on>アク</on>
+			<kun>わる・い</kun>
+			<kun>わろ・し</kun>
+			<kun>にく・い</kun>
+		</kanji>
+		<kanji>
+			<char>安</char>
+			<meaning>Feel rested; Cheap; Peaceful</meaning>
+			<kun>やす・い</kun>
+			<kun>やす・まる</kun>
+			<kun>やす・んじる</kun>
+			<kun>やす・らう</kun>
+			<on>アン</on>
+			<kun>やす</kun>
+			<kun>やす・らぐ</kun>
+			<kun>やす・らか</kun>
+		</kanji>
+		<kanji>
+			<char>暗</char>
+			<meaning>Dark; Dim; Obscured</meaning>
+			<kun>くら・い</kun>
+			<on>アン</on>
+		</kanji>
+		<kanji>
+			<char>委</char>
+			<meaning>Entrust; Details; Trustee</meaning>
+			<kun>ゆだ・ねる</kun>
+			<kun>まか・せる</kun>
+			<on>イ</on>
+			<kun>くわ・しい</kun>
+		</kanji>
+		<kanji>
+			<char>意</char>
+			<meaning>Will; Meaning; Intention</meaning>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>医</char>
+			<meaning>Medicine; Doctor</meaning>
+			<kun>い・する</kun>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>育</char>
+			<meaning>Nurture; Bring up; Tend</meaning>
+			<kun>そだ・つ</kun>
+			<on>イク</on>
+			<kun>そだ・てる</kun>
+		</kanji>
+		<kanji>
+			<char>員</char>
+			<meaning>Member; Employee; Staff</meaning>
+			<on>イン</on>
+		</kanji>
+		<kanji>
+			<char>飲</char>
+			<meaning>Drink; Smoke; Beverage</meaning>
+			<kun>の・む</kun>
+			<on>イン</on>
+			<on>オン</on>
+		</kanji>
+		<kanji>
+			<char>院</char>
+			<meaning>Clinic; Institution; Monastery</meaning>
+			<on>イン</on>
+		</kanji>
+		<kanji>
+			<char>運</char>
+			<meaning>Transport; Luck; Fate</meaning>
+			<kun>はこ・ぶ</kun>
+			<on>ウン</on>
+		</kanji>
+		<kanji>
+			<char>泳</char>
+			<meaning>Swim</meaning>
+			<kun>およ・ぐ</kun>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>駅</char>
+			<meaning>Station</meaning>
+			<on>エキ</on>
+		</kanji>
+		<kanji>
+			<char>央</char>
+			<meaning>Centre; Middle</meaning>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>横</char>
+			<meaning>Side; Horizontal</meaning>
+			<kun>よこ</kun>
+			<kun>よこ・たわる</kun>
+			<on>オウ</on>
+			<kun>よこ・たえる</kun>
+		</kanji>
+		<kanji>
+			<char>屋</char>
+			<meaning>Room; Shed; Seller</meaning>
+			<kun>や</kun>
+			<on>オク</on>
+		</kanji>
+		<kanji>
+			<char>温</char>
+			<meaning>Become warm; Heat; Temperature</meaning>
+			<kun>あたた・かい</kun>
+			<kun>あたたか・まる</kun>
+			<kun>ぬる・める</kun>
+			<kun>ぬる・む</kun>
+			<kun>ぬく・む</kun>
+			<on>オン</on>
+			<kun>あたたか・める</kun>
+			<kun>ぬる・い</kun>
+			<kun>ぬく・める</kun>
+			<kun>ぬく</kun>
+		</kanji>
+		<kanji>
+			<char>化</char>
+			<meaning>Change; Disguise; Enchant</meaning>
+			<on>ケ</on>
+			<kun>ば・かす</kun>
+			<on>カ</on>
+			<kun>ば・ける</kun>
+			<kun>ふ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>荷</char>
+			<meaning>Shoulder a burden; Luggage; Cargo</meaning>
+			<kun>に</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>界</char>
+			<meaning>World</meaning>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>開</char>
+			<meaning>Open; Unfold</meaning>
+			<kun>あ・く</kun>
+			<kun>ひら・く</kun>
+			<on>カイ</on>
+			<kun>あ・ける</kun>
+			<kun>ひら・ける</kun>
+		</kanji>
+		<kanji>
+			<char>階</char>
+			<meaning>Storey; Floor; Rank</meaning>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>寒</char>
+			<meaning>Cold; Chill</meaning>
+			<kun>さむ・い</kun>
+			<on>カン</on>
+			<kun>さむ・がる</kun>
+		</kanji>
+		<kanji>
+			<char>感</char>
+			<meaning>Feel; Sensation; Emotion</meaning>
+			<kun>かん・じる</kun>
+			<on>カン</on>
+			<kun>かん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>漢</char>
+			<meaning>China; Han dynasty; Fellow, person</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>館</char>
+			<meaning>Mansion; Palace; Archive</meaning>
+			<kun>やかた</kun>
+			<on>カン</on>
+			<kun>たち</kun>
+		</kanji>
+		<kanji>
+			<char>岸</char>
+			<meaning>Coast; Bank; Beach</meaning>
+			<kun>きし</kun>
+			<on>ガン</on>
+		</kanji>
+		<kanji>
+			<char>期</char>
+			<meaning>Season; Period; Term</meaning>
+			<on>ゴ</on>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>起</char>
+			<meaning>Occur; Get up; Happening</meaning>
+			<kun>お・きる</kun>
+			<kun>お・こす</kun>
+			<on>キ</on>
+			<kun>お・こる</kun>
+		</kanji>
+		<kanji>
+			<char>客</char>
+			<meaning>Guest; Customer; Visitor</meaning>
+			<on>カク</on>
+			<on>キャク</on>
+		</kanji>
+		<kanji>
+			<char>宮</char>
+			<meaning>Shrine; Palace; Constellation</meaning>
+			<on>グウ</on>
+			<kun>みや</kun>
+			<on>キュウ</on>
+			<on>ク</on>
+		</kanji>
+		<kanji>
+			<char>急</char>
+			<meaning>Hurry; Urgent; Express</meaning>
+			<kun>いそ・ぐ</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>球</char>
+			<meaning>Ball; Sphere; Globe</meaning>
+			<kun>たま</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>究</char>
+			<meaning>Gain mastery; Research; Study</meaning>
+			<kun>きわ・める</kun>
+			<on>クっ</on>
+			<on>キュウ</on>
+			<on>クツ</on>
+		</kanji>
+		<kanji>
+			<char>級</char>
+			<meaning>Grade; Rank; Class</meaning>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>去</char>
+			<meaning>Leave; Pass away; Previous</meaning>
+			<on>コ</on>
+			<on>キョ</on>
+			<kun>さ・る</kun>
+		</kanji>
+		<kanji>
+			<char>橋</char>
+			<meaning>Bridge; Wharf</meaning>
+			<kun>はし</kun>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>業</char>
+			<meaning>Business; Industry; Work</meaning>
+			<on>ゴウ</on>
+			<on>ギョウ</on>
+			<kun>わざ</kun>
+		</kanji>
+		<kanji>
+			<char>局</char>
+			<meaning>Office; Channel; Lady in waiting</meaning>
+			<kun>つぼね</kun>
+			<on>キョク</on>
+		</kanji>
+		<kanji>
+			<char>曲</char>
+			<meaning>Bend; Turn; Melody</meaning>
+			<kun>ま・げる</kun>
+			<on>キョク</on>
+			<kun>ま・がる</kun>
+		</kanji>
+		<kanji>
+			<char>銀</char>
+			<meaning>Silver</meaning>
+			<kun>しろがね</kun>
+			<on>ギン</on>
+		</kanji>
+		<kanji>
+			<char>区</char>
+			<meaning>Ward; District; Section</meaning>
+			<kun>まち</kun>
+			<on>ク</on>
+		</kanji>
+		<kanji>
+			<char>苦</char>
+			<meaning>Suffer; Bitter; Painful</meaning>
+			<kun>くる・しい</kun>
+			<kun>くる・しめる</kun>
+			<kun>にが・る</kun>
+			<on>ク</on>
+			<kun>くる・しむ</kun>
+			<kun>にが・い</kun>
+		</kanji>
+		<kanji>
+			<char>具</char>
+			<meaning>Be endowed with; Tool; In detail</meaning>
+			<kun>そな・える</kun>
+			<on>グ</on>
+			<kun>つぶさ・に</kun>
+		</kanji>
+		<kanji>
+			<char>君</char>
+			<meaning>You; Mr.; Master</meaning>
+			<kun>きみ</kun>
+			<on>クン</on>
+		</kanji>
+		<kanji>
+			<char>係</char>
+			<meaning>Concern; Official; Agent</meaning>
+			<kun>かか・る</kun>
+			<kun>かか・わる</kun>
+			<on>ケイ</on>
+			<kun>かかり</kun>
+		</kanji>
+		<kanji>
+			<char>軽</char>
+			<meaning>Make light of; Minor; Easy</meaning>
+			<kun>かる・い</kun>
+			<kun>かろ・んじる</kun>
+			<on>ケイ</on>
+			<kun>かろ・やか</kun>
+		</kanji>
+		<kanji>
+			<char>決</char>
+			<meaning>Decide; Settle; Never</meaning>
+			<kun>き・める</kun>
+			<kun>け・して</kun>
+			<on>ケツ</on>
+			<kun>き・まる</kun>
+		</kanji>
+		<kanji>
+			<char>血</char>
+			<meaning>Blood</meaning>
+			<kun>ち</kun>
+			<on>ケツ</on>
+		</kanji>
+		<kanji>
+			<char>研</char>
+			<meaning>Sharpen; Hone; Study</meaning>
+			<kun>と・ぐ</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>県</char>
+			<meaning>Prefecture</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>庫</char>
+			<meaning>Warehouse; Storage; Vault</meaning>
+			<on>ク</on>
+			<on>コ</on>
+			<kun>くら</kun>
+		</kanji>
+		<kanji>
+			<char>湖</char>
+			<meaning>Lake</meaning>
+			<kun>みずうみ</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>向</char>
+			<meaning>Face; Opposite; Direction</meaning>
+			<kun>む・こう</kun>
+			<kun>む・かう</kun>
+			<on>コウ</on>
+			<kun>む・く</kun>
+		</kanji>
+		<kanji>
+			<char>幸</char>
+			<meaning>Happy; Blessing</meaning>
+			<kun>さち</kun>
+			<kun>しあわ・せ</kun>
+			<on>コウ</on>
+			<kun>さいわ・い</kun>
+		</kanji>
+		<kanji>
+			<char>港</char>
+			<meaning>Harbour; Port</meaning>
+			<kun>みなと</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>号</char>
+			<meaning>Number; Sign; Signal</meaning>
+			<on>ゴウ</on>
+		</kanji>
+		<kanji>
+			<char>根</char>
+			<meaning>Root; Origin</meaning>
+			<kun>ね</kun>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>祭</char>
+			<meaning>Enshrine; Festival; Service</meaning>
+			<kun>まつ・る</kun>
+			<on>サイ</on>
+			<kun>まつり</kun>
+		</kanji>
+		<kanji>
+			<char>坂</char>
+			<meaning>Slope; Hill</meaning>
+			<on>ハン</on>
+			<kun>さか</kun>
+		</kanji>
+		<kanji>
+			<char>皿</char>
+			<meaning>Plate; Dish</meaning>
+			<kun>さら</kun>
+			<on>ベイ</on>
+		</kanji>
+		<kanji>
+			<char>仕</char>
+			<meaning>Serve; Attendant</meaning>
+			<on>ジ</on>
+			<on>シ</on>
+			<kun>つか・える</kun>
+		</kanji>
+		<kanji>
+			<char>使</char>
+			<meaning>Use; Employ; Messenger</meaning>
+			<kun>つか・う</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>始</char>
+			<meaning>Begin; Start</meaning>
+			<kun>はじ・める</kun>
+			<on>シ</on>
+			<kun>はじ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>指</char>
+			<meaning>Point at; Finger</meaning>
+			<kun>ゆび</kun>
+			<on>シ</on>
+			<kun>さ・す</kun>
+		</kanji>
+		<kanji>
+			<char>死</char>
+			<meaning>Die; Death</meaning>
+			<kun>し・ぬ</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>詩</char>
+			<meaning>Poetry; Verse</meaning>
+			<kun>うた</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>歯</char>
+			<meaning>Tooth</meaning>
+			<kun>は</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>事</char>
+			<meaning>Thing; Deed; Event</meaning>
+			<on>ズ</on>
+			<on>ジ</on>
+			<kun>こと</kun>
+		</kanji>
+		<kanji>
+			<char>持</char>
+			<meaning>Hold; Carry</meaning>
+			<kun>も・つ</kun>
+			<on>ジ</on>
+			<kun>も・てる</kun>
+		</kanji>
+		<kanji>
+			<char>次</char>
+			<meaning>Follow after; Next; Sequence</meaning>
+			<on>シ</on>
+			<kun>つぎ</kun>
+			<on>ジ</on>
+			<kun>つ・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>式</char>
+			<meaning>Ceremony; Style; Equation</meaning>
+			<on>シキ</on>
+		</kanji>
+		<kanji>
+			<char>実</char>
+			<meaning>Bear fruit; Truth; Fruit</meaning>
+			<on>ジツ</on>
+			<kun>まこと</kun>
+			<kun>み</kun>
+			<kun>みの・る</kun>
+			<on>ジっ</on>
+		</kanji>
+		<kanji>
+			<char>写</char>
+			<meaning>Photograph; Transcribe; Project</meaning>
+			<on>ジャ</on>
+			<kun>うつ・す</kun>
+			<on>シャ</on>
+			<kun>うつ・る</kun>
+		</kanji>
+		<kanji>
+			<char>者</char>
+			<meaning>Person</meaning>
+			<kun>もの</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>主</char>
+			<meaning>Master; Lord; Main</meaning>
+			<on>シュ</on>
+			<kun>ぬし</kun>
+			<kun>あるじ</kun>
+			<on>シュウ</on>
+			<on>ス</on>
+			<kun>おも</kun>
+		</kanji>
+		<kanji>
+			<char>取</char>
+			<meaning>Take; Pick up; Fetch</meaning>
+			<kun>と・る</kun>
+			<on>シュ</on>
+			<kun>-とり</kun>
+		</kanji>
+		<kanji>
+			<char>守</char>
+			<meaning>Protect; Watch over; Uphold</meaning>
+			<on>ス</on>
+			<kun>もり</kun>
+			<on>シュ</on>
+			<on>-ジュ</on>
+			<kun>まも・る</kun>
+		</kanji>
+		<kanji>
+			<char>酒</char>
+			<meaning>Sake; Alcohol</meaning>
+			<kun>さけ</kun>
+			<on>シュ</on>
+			<kun>さか</kun>
+		</kanji>
+		<kanji>
+			<char>受</char>
+			<meaning>Accept; Undertake; Receive</meaning>
+			<kun>う・ける</kun>
+			<on>ジュ</on>
+			<kun>う・かる</kun>
+		</kanji>
+		<kanji>
+			<char>州</char>
+			<meaning>Province; State; Sandbank</meaning>
+			<on>す</on>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>拾</char>
+			<meaning>Pick up; Gather; Find</meaning>
+			<on>ジュウ</on>
+			<on>シュウ</on>
+			<kun>ひろ・う</kun>
+		</kanji>
+		<kanji>
+			<char>終</char>
+			<meaning>End; Final</meaning>
+			<kun>おわ・る</kun>
+			<kun>つい</kun>
+			<on>シュウ</on>
+			<kun>お・える</kun>
+		</kanji>
+		<kanji>
+			<char>習</char>
+			<meaning>Learn; Study; Practice</meaning>
+			<on>ジュ</on>
+			<kun>なら・い</kun>
+			<on>シュウ</on>
+			<kun>なら・う</kun>
+		</kanji>
+		<kanji>
+			<char>集</char>
+			<meaning>Gather; Assemble; Flock</meaning>
+			<kun>あつ・める</kun>
+			<kun>つど・う</kun>
+			<on>シュウ</on>
+			<kun>あつ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>住</char>
+			<meaning>Reside; Dwell; Live</meaning>
+			<kun>す・む</kun>
+			<kun>ずまい</kun>
+			<kun>すま</kun>
+			<on>ジュウ</on>
+			<kun>す・まう</kun>
+			<kun>すみ</kun>
+		</kanji>
+		<kanji>
+			<char>重</char>
+			<meaning>Get heavy; Weighty; Principal</meaning>
+			<on>チョウ</on>
+			<kun>おも・い</kun>
+			<on>ジュウ</on>
+			<kun>え</kun>
+			<kun>おも・る</kun>
+		</kanji>
+		<kanji>
+			<char>宿</char>
+			<meaning>Lodge; Shelter; Inn</meaning>
+			<kun>やど</kun>
+			<kun>やど・す</kun>
+			<on>シュク</on>
+			<kun>やど・る</kun>
+		</kanji>
+		<kanji>
+			<char>所</char>
+			<meaning>Place</meaning>
+			<kun>ところ</kun>
+			<kun>とこ</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>暑</char>
+			<meaning>Hot; Warm</meaning>
+			<kun>あつ・い</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>助</char>
+			<meaning>Help; Assist; Save</meaning>
+			<kun>すけ</kun>
+			<kun>たす・ける</kun>
+			<on>ジョ</on>
+			<kun>す・ける</kun>
+			<kun>たす・かる</kun>
+		</kanji>
+		<kanji>
+			<char>勝</char>
+			<meaning>Win; Triumph; Surpass</meaning>
+			<kun>か・つ</kun>
+			<kun>すぐ・れる</kun>
+			<kun>かっ</kun>
+			<on>ショウ</on>
+			<kun>まさ・る</kun>
+			<kun>か・ち</kun>
+		</kanji>
+		<kanji>
+			<char>商</char>
+			<meaning>Sell; Trade; Merchant</meaning>
+			<kun>あきな・う</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>昭</char>
+			<meaning>Shining; Bright</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>消</char>
+			<meaning>Vanish; Extinguish; Cancel</meaning>
+			<kun>き・える</kun>
+			<on>ショウ</on>
+			<kun>け・す</kun>
+		</kanji>
+		<kanji>
+			<char>章</char>
+			<meaning>Badge; Medal; Chapter</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>乗</char>
+			<meaning>Ride; Board; Take advantage of</meaning>
+			<on>ジョウ</on>
+			<kun>の・る</kun>
+			<kun>じょう・ずる</kun>
+			<kun>じょう・じる</kun>
+			<on>ショウ</on>
+			<kun>の・せる</kun>
+		</kanji>
+		<kanji>
+			<char>植</char>
+			<meaning>Grow; Plant; Vegetation</meaning>
+			<kun>う・える</kun>
+			<on>ショク</on>
+			<kun>う・わる</kun>
+		</kanji>
+		<kanji>
+			<char>深</char>
+			<meaning>Deep; Profound; Intense</meaning>
+			<kun>ふか・い</kun>
+			<kun>ふか・まる</kun>
+			<on>シン</on>
+			<kun>ふか・める</kun>
+		</kanji>
+		<kanji>
+			<char>申</char>
+			<meaning>Say; Be called</meaning>
+			<kun>もう・す</kun>
+			<on>シン</on>
+			<kun>さる</kun>
+		</kanji>
+		<kanji>
+			<char>真</char>
+			<meaning>True; Just</meaning>
+			<kun>ま</kun>
+			<on>シン</on>
+			<kun>まこと</kun>
+		</kanji>
+		<kanji>
+			<char>神</char>
+			<meaning>God; Spirit</meaning>
+			<kun>かみ</kun>
+			<on>シン</on>
+			<kun>こう</kun>
+			<on>ジン</on>
+			<kun>かん</kun>
+		</kanji>
+		<kanji>
+			<char>身</char>
+			<meaning>Body; Self; Place in life</meaning>
+			<kun>み</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>進</char>
+			<meaning>Advance; Progress; Proceed</meaning>
+			<kun>すす・む</kun>
+			<on>シン</on>
+			<kun>すす・める</kun>
+		</kanji>
+		<kanji>
+			<char>世</char>
+			<meaning>World; Generation; Public</meaning>
+			<on>セイ</on>
+			<on>セ</on>
+			<kun>よ</kun>
+		</kanji>
+		<kanji>
+			<char>整</char>
+			<meaning>Be prepared; Regular; Adjustment</meaning>
+			<kun>ととの・う</kun>
+			<on>セイ</on>
+			<kun>ととの・える</kun>
+		</kanji>
+		<kanji>
+			<char>昔</char>
+			<meaning>Long ago; Ancient times</meaning>
+			<on>シャク</on>
+			<on>セキ</on>
+			<kun>むかし</kun>
+		</kanji>
+		<kanji>
+			<char>全</char>
+			<meaning>Entire; Whole</meaning>
+			<kun>まった・く</kun>
+			<on>ゼン</on>
+			<kun>すべ・て</kun>
+		</kanji>
+		<kanji>
+			<char>想</char>
+			<meaning>Idea; Concept; Thought</meaning>
+			<on>ソ</on>
+			<on>ソウ</on>
+			<kun>おも・う</kun>
+		</kanji>
+		<kanji>
+			<char>相</char>
+			<meaning>Mutual; Together; Minister</meaning>
+			<on>ショウ</on>
+			<on>ソウ</on>
+			<kun>あい</kun>
+		</kanji>
+		<kanji>
+			<char>送</char>
+			<meaning>Send; Convey; Transmit</meaning>
+			<kun>おく・る</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>息</char>
+			<meaning>Breath; Son</meaning>
+			<kun>いき</kun>
+			<on>ソク</on>
+		</kanji>
+		<kanji>
+			<char>速</char>
+			<meaning>Speed up; Hasten; Fast</meaning>
+			<kun>はや・い</kun>
+			<kun>はや・める</kun>
+			<kun>はや・まる</kun>
+			<on>ソク</on>
+			<kun>はや</kun>
+			<kun>すみ・やか</kun>
+		</kanji>
+		<kanji>
+			<char>族</char>
+			<meaning>Family; Tribe; Clan</meaning>
+			<on>ゾク</on>
+		</kanji>
+		<kanji>
+			<char>他</char>
+			<meaning>Another; Some other</meaning>
+			<kun>ほか</kun>
+			<on>タ</on>
+		</kanji>
+		<kanji>
+			<char>打</char>
+			<meaning>Strike; Hit</meaning>
+			<kun>う・つ</kun>
+			<on>ダ</on>
+		</kanji>
+		<kanji>
+			<char>対</char>
+			<meaning>Confront; Against; Versus</meaning>
+			<on>ツイ</on>
+			<on>タイ</on>
+			<kun>むか・う</kun>
+		</kanji>
+		<kanji>
+			<char>待</char>
+			<meaning>Wait</meaning>
+			<kun>ま・つ</kun>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>代</char>
+			<meaning>Replace; Generation; Era</meaning>
+			<on>タイ</on>
+			<kun>かわ・る</kun>
+			<kun>しろ</kun>
+			<on>ダイ</on>
+			<kun>か・える</kun>
+			<kun>よ</kun>
+		</kanji>
+		<kanji>
+			<char>第</char>
+			<meaning>Ordinal</meaning>
+			<on>ダイ</on>
+		</kanji>
+		<kanji>
+			<char>題</char>
+			<meaning>Topic; Subject</meaning>
+			<on>ダイ</on>
+		</kanji>
+		<kanji>
+			<char>炭</char>
+			<meaning>Coal; Charcoal; Carbon</meaning>
+			<kun>すみ</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>短</char>
+			<meaning>Short</meaning>
+			<kun>みじか・い</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>談</char>
+			<meaning>Conversation; Account; Story</meaning>
+			<on>ダン</on>
+		</kanji>
+		<kanji>
+			<char>着</char>
+			<meaning>Arrive; Wear; Suit of clothes</meaning>
+			<on>ジャク</on>
+			<kun>き・せる</kun>
+			<kun>-ぎ</kun>
+			<kun>つ・ける</kun>
+			<on>チャク</on>
+			<kun>き・る</kun>
+			<kun>つ・く</kun>
+		</kanji>
+		<kanji>
+			<char>柱</char>
+			<meaning>Pillar; Post; Column</meaning>
+			<kun>はしら</kun>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>注</char>
+			<meaning>Pour; Irrigate; Comment</meaning>
+			<kun>つ・ぐ</kun>
+			<kun>さ・す</kun>
+			<on>チュウ</on>
+			<kun>そそ・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>丁</char>
+			<meaning>City block; Ward; Page</meaning>
+			<on>テイ</on>
+			<on>トウ</on>
+			<on>チョウ</on>
+			<kun>ひのと</kun>
+		</kanji>
+		<kanji>
+			<char>帳</char>
+			<meaning>Curtain; Notebook; Register</meaning>
+			<kun>とばり</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>調</char>
+			<meaning>Prepare; Investigate; Musical key</meaning>
+			<kun>しら・べる</kun>
+			<kun>ととの・える</kun>
+			<on>チョウ</on>
+			<kun>ととの・う</kun>
+		</kanji>
+		<kanji>
+			<char>追</char>
+			<meaning>Chase; Follow; Drive away</meaning>
+			<kun>お・う</kun>
+			<on>ツイ</on>
+		</kanji>
+		<kanji>
+			<char>定</char>
+			<meaning>Determine; Definite; Certain</meaning>
+			<on>ジョウ</on>
+			<kun>さだ・める</kun>
+			<on>テイ</on>
+			<kun>さだ・か</kun>
+			<kun>さだ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>庭</char>
+			<meaning>Garden; Courtyard</meaning>
+			<kun>にわ</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>笛</char>
+			<meaning>Flute; Pipe; Whistle</meaning>
+			<kun>ふえ</kun>
+			<on>テキ</on>
+		</kanji>
+		<kanji>
+			<char>鉄</char>
+			<meaning>Iron</meaning>
+			<kun>くろがね</kun>
+			<on>テツ</on>
+		</kanji>
+		<kanji>
+			<char>転</char>
+			<meaning>Roll; Tumble; Fall down</meaning>
+			<kun>ころ・がる</kun>
+			<kun>こ・ける</kun>
+			<kun>ころ・げる</kun>
+			<kun>まろ・ぶ</kun>
+			<kun>ころ・ぶ</kun>
+			<on>テン</on>
+			<kun>ころ・がす</kun>
+		</kanji>
+		<kanji>
+			<char>登</char>
+			<meaning>Climb; Ascend</meaning>
+			<kun>のぼ・る</kun>
+			<on>ト</on>
+			<on>トウ</on>
+			<kun>あ・がる</kun>
+		</kanji>
+		<kanji>
+			<char>都</char>
+			<meaning>Metropolis; Capital</meaning>
+			<on>ツ</on>
+			<on>ト</on>
+			<kun>みやこ</kun>
+		</kanji>
+		<kanji>
+			<char>度</char>
+			<meaning>Degree; Occurrence</meaning>
+			<on>タク</on>
+			<kun>たび</kun>
+			<on>ド</on>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>島</char>
+			<meaning>Island</meaning>
+			<kun>しま</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>投</char>
+			<meaning>Cast; Throw; Pitch</meaning>
+			<kun>な・げる</kun>
+			<on>トウ</on>
+			<kun>な・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>湯</char>
+			<meaning>Hot water; Bath</meaning>
+			<kun>ゆ</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>等</char>
+			<meaning>Equal; And the like; Grade</meaning>
+			<kun>ひと・しい</kun>
+			<kun>-ら</kun>
+			<on>トウ</on>
+			<kun>など</kun>
+		</kanji>
+		<kanji>
+			<char>豆</char>
+			<meaning>Bean; Pea; Legume</meaning>
+			<on>ズ</on>
+			<on>トウ</on>
+			<kun>まめ</kun>
+		</kanji>
+		<kanji>
+			<char>動</char>
+			<meaning>Move; Get excited; Motion</meaning>
+			<kun>うご・く</kun>
+			<kun>どう・じる</kun>
+			<on>ドウ</on>
+			<kun>うご・かす</kun>
+			<kun>どう・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>童</char>
+			<meaning>Child</meaning>
+			<kun>わらべ</kun>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>農</char>
+			<meaning>Agriculture; Farming</meaning>
+			<on>ノウ</on>
+		</kanji>
+		<kanji>
+			<char>波</char>
+			<meaning>Waves</meaning>
+			<kun>なみ</kun>
+			<on>ハ</on>
+		</kanji>
+		<kanji>
+			<char>配</char>
+			<meaning>Distribute; Deploy</meaning>
+			<kun>くば・る</kun>
+			<on>ハイ</on>
+		</kanji>
+		<kanji>
+			<char>倍</char>
+			<meaning>Double; Times over</meaning>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>箱</char>
+			<meaning>Box; Case</meaning>
+			<kun>はこ</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>畑</char>
+			<meaning>Field</meaning>
+			<kun>はたけ</kun>
+			<kun>はた</kun>
+		</kanji>
+		<kanji>
+			<char>発</char>
+			<meaning>Emit; Release; Disclose</meaning>
+			<on>ホツ</on>
+			<kun>た・つ</kun>
+			<on>ハツ</on>
+			<kun>はな・つ</kun>
+			<kun>あば・く</kun>
+		</kanji>
+		<kanji>
+			<char>反</char>
+			<meaning>Warp; Change; Rebel</meaning>
+			<on>ホン</on>
+			<kun>そ・る</kun>
+			<kun>かえ・る</kun>
+			<on>ハン</on>
+			<on>タン</on>
+			<kun>かえ・す</kun>
+			<kun>そ・らす</kun>
+		</kanji>
+		<kanji>
+			<char>板</char>
+			<meaning>Plank; Board; Deck</meaning>
+			<on>バン</on>
+			<on>ハン</on>
+			<kun>いた</kun>
+		</kanji>
+		<kanji>
+			<char>悲</char>
+			<meaning>Be sad; Grieve; Miserable</meaning>
+			<kun>かな・しい</kun>
+			<on>ヒ</on>
+			<kun>かな・しむ</kun>
+		</kanji>
+		<kanji>
+			<char>皮</char>
+			<meaning>Skin; Hide; Leather</meaning>
+			<kun>かわ</kun>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>美</char>
+			<meaning>Beautiful; Splendid</meaning>
+			<on>ミ</on>
+			<on>ビ</on>
+			<kun>うつく・しい</kun>
+		</kanji>
+		<kanji>
+			<char>鼻</char>
+			<meaning>Nose; Trunk</meaning>
+			<kun>はな</kun>
+			<on>ビ</on>
+		</kanji>
+		<kanji>
+			<char>筆</char>
+			<meaning>Writing brush; Pen</meaning>
+			<kun>ふで</kun>
+			<on>ヒツ</on>
+		</kanji>
+		<kanji>
+			<char>氷</char>
+			<meaning>Freezing; Ice; Hail</meaning>
+			<kun>ひ</kun>
+			<kun>こお・る</kun>
+			<on>ヒョウ</on>
+			<kun>こおり</kun>
+		</kanji>
+		<kanji>
+			<char>表</char>
+			<meaning>Reveal; Express; Surface</meaning>
+			<kun>おもて</kun>
+			<kun>あらわ・れる</kun>
+			<on>ヒョウ</on>
+			<kun>あらわ・す</kun>
+		</kanji>
+		<kanji>
+			<char>病</char>
+			<meaning>Fall ill; Illness; Disease</meaning>
+			<on>ヘイ</on>
+			<kun>やまい</kun>
+			<on>ビョウ</on>
+			<kun>や・む</kun>
+		</kanji>
+		<kanji>
+			<char>秒</char>
+			<meaning>Second of minute</meaning>
+			<on>ビョウ</on>
+		</kanji>
+		<kanji>
+			<char>品</char>
+			<meaning>Item; Article; Refined</meaning>
+			<kun>しな</kun>
+			<on>ヒン</on>
+			<on>ホン</on>
+		</kanji>
+		<kanji>
+			<char>負</char>
+			<meaning>Defeat; Owe; Negative</meaning>
+			<kun>ま・ける</kun>
+			<kun>お・う</kun>
+			<on>フ</on>
+			<kun>ま・かす</kun>
+		</kanji>
+		<kanji>
+			<char>部</char>
+			<meaning>Part; Section; Department</meaning>
+			<kun>べ</kun>
+			<on>ブ</on>
+		</kanji>
+		<kanji>
+			<char>服</char>
+			<meaning>Clothing; Submission</meaning>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>福</char>
+			<meaning>Luck; Fortune; Blessing</meaning>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>物</char>
+			<meaning>Object; Article; Substance</meaning>
+			<on>モツ</on>
+			<on>ブツ</on>
+			<kun>もの</kun>
+		</kanji>
+		<kanji>
+			<char>平</char>
+			<meaning>Flat; Even; Peaceful</meaning>
+			<on>ヒョウ</on>
+			<kun>たい・ら</kun>
+			<kun>たい・らげる</kun>
+			<kun>ひら・たい</kun>
+			<on>ヘイ</on>
+			<on>ビョウ</on>
+			<kun>たい・らぐ</kun>
+			<kun>ひら</kun>
+		</kanji>
+		<kanji>
+			<char>返</char>
+			<meaning>Return; Reply</meaning>
+			<kun>かえ・す</kun>
+			<on>ヘン</on>
+			<kun>かえ・る</kun>
+		</kanji>
+		<kanji>
+			<char>勉</char>
+			<meaning>Endeavour; Diligence</meaning>
+			<kun>つと・める</kun>
+			<on>ベン</on>
+		</kanji>
+		<kanji>
+			<char>放</char>
+			<meaning>Loose; Release; Separate</meaning>
+			<kun>はな・す</kun>
+			<kun>はな・れる</kun>
+			<on>ホウ</on>
+			<kun>はな・つ</kun>
+			<kun>ほう・る</kun>
+		</kanji>
+		<kanji>
+			<char>味</char>
+			<meaning>Taste; Flavour</meaning>
+			<kun>あじ</kun>
+			<on>ミ</on>
+			<kun>あじ・わう</kun>
+		</kanji>
+		<kanji>
+			<char>命</char>
+			<meaning>Command; Life; Lord</meaning>
+			<on>ミョウ</on>
+			<kun>めい・じる</kun>
+			<on>メイ</on>
+			<kun>いのち</kun>
+			<kun>めい・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>面</char>
+			<meaning>Face; Surface; Mask</meaning>
+			<on>ベン</on>
+			<kun>おもて</kun>
+			<on>メン</on>
+			<kun>おも</kun>
+			<kun>つら</kun>
+		</kanji>
+		<kanji>
+			<char>問</char>
+			<meaning>Ask; Question; Problem</meaning>
+			<kun>と・う</kun>
+			<kun>と・い</kun>
+			<on>モン</on>
+			<kun>とん</kun>
+		</kanji>
+		<kanji>
+			<char>役</char>
+			<meaning>Campaign; Battle; Role</meaning>
+			<on>エキ</on>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>薬</char>
+			<meaning>Medicine; Chemical</meaning>
+			<kun>くすり</kun>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>油</char>
+			<meaning>Oil; Grease</meaning>
+			<on>ユ</on>
+			<on>ユウ</on>
+			<kun>あぶら</kun>
+		</kanji>
+		<kanji>
+			<char>有</char>
+			<meaning>Have; Possess; Exist</meaning>
+			<kun>あ・る</kun>
+			<on>ユウ</on>
+			<on>ウ</on>
+		</kanji>
+		<kanji>
+			<char>由</char>
+			<meaning>Reason; Cause</meaning>
+			<on>ユウ</on>
+			<kun>よし</kun>
+			<on>ユ</on>
+			<on>ユイ</on>
+			<kun>よ・る</kun>
+		</kanji>
+		<kanji>
+			<char>遊</char>
+			<meaning>Play; Excursion</meaning>
+			<on>ユ</on>
+			<kun>あそ・ばす</kun>
+			<on>ユウ</on>
+			<kun>あそ・ぶ</kun>
+		</kanji>
+		<kanji>
+			<char>予</char>
+			<meaning>In advance; Previously; Preparation</meaning>
+			<kun>あらかじ・め</kun>
+			<on>ヨ</on>
+			<kun>かね・て</kun>
+		</kanji>
+		<kanji>
+			<char>様</char>
+			<meaning>Appearance; Way; Sir</meaning>
+			<kun>さま</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>洋</char>
+			<meaning>Ocean; Western</meaning>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>羊</char>
+			<meaning>Sheep</meaning>
+			<kun>ひつじ</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>葉</char>
+			<meaning>Leaf; Page</meaning>
+			<kun>は</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>陽</char>
+			<meaning>Sunlight; Positive</meaning>
+			<kun>ひ</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>落</char>
+			<meaning>Drop; Fall</meaning>
+			<kun>お・ちる</kun>
+			<on>ラク</on>
+			<kun>お・とす</kun>
+		</kanji>
+		<kanji>
+			<char>流</char>
+			<meaning>Drain; Flow; Stream</meaning>
+			<on>ル</on>
+			<kun>なが・れる</kun>
+			<on>リュウ</on>
+			<kun>なが・す</kun>
+		</kanji>
+		<kanji>
+			<char>旅</char>
+			<meaning>Journey; Travel; Trip</meaning>
+			<kun>たび</kun>
+			<on>リョ</on>
+		</kanji>
+		<kanji>
+			<char>両</char>
+			<meaning>Both; Double; Old unit of currency; Counter for vehicles</meaning>
+			<on>リョウ</on>
+			<kun>もろ</kun>
+		</kanji>
+		<kanji>
+			<char>緑</char>
+			<meaning>Green</meaning>
+			<on>ロク</on>
+			<on>リョク</on>
+			<kun>みどり</kun>
+		</kanji>
+		<kanji>
+			<char>礼</char>
+			<meaning>Gratitude; Courtesy; Bowing; Ceremony</meaning>
+			<on>ライ</on>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>列</char>
+			<meaning>Line; Row; Rank</meaning>
+			<on>レ</on>
+			<on>レツ</on>
+		</kanji>
+		<kanji>
+			<char>練</char>
+			<meaning>Train; Drill; Knead</meaning>
+			<on>レン</on>
+		</kanji>
+		<kanji>
+			<char>路</char>
+			<meaning>Route; Road; Path</meaning>
+			<kun>みち</kun>
+			<on>ロ</on>
+			<kun>じ</kun>
+		</kanji>
+		<kanji>
+			<char>和</char>
+			<meaning>Calm down; Soften; Peace</meaning>
+			<on>オ</on>
+			<kun>やわ・らげる</kun>
+			<kun>なご・やか</kun>
+			<on>ワ</on>
+			<kun>やわ・らぐ</kun>
+			<kun>なご・む</kun>
+		</kanji>
+	</category>
+	<category id="kanji_4">
+		<kanji>
+			<char>愛</char>
+			<meaning>Love; Beloved</meaning>
+			<kun>いと・しい</kun>
+			<on>アイ</on>
+		</kanji>
+		<kanji>
+			<char>案</char>
+			<meaning>Draft; Proposal; Plan</meaning>
+			<on>アン</on>
+		</kanji>
+		<kanji>
+			<char>以</char>
+			<meaning>By means of; Up to; Since</meaning>
+			<kun>も・て</kun>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>位</char>
+			<meaning>Ranking; The Throne; To the extent that</meaning>
+			<kun>くらい</kun>
+			<on>イ</on>
+			<kun>ぐらい</kun>
+		</kanji>
+		<kanji>
+			<char>囲</char>
+			<meaning>Encircle; Enclose; Besiege</meaning>
+			<kun>かこ・む</kun>
+			<kun>かこ・い</kun>
+			<on>イ</on>
+			<kun>かこ・う</kun>
+		</kanji>
+		<kanji>
+			<char>胃</char>
+			<meaning>Stomach</meaning>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>衣</char>
+			<meaning>Clothing</meaning>
+			<kun>ころも</kun>
+			<on>イ</on>
+			<on>エ</on>
+		</kanji>
+		<kanji>
+			<char>印</char>
+			<meaning>Seal; Insignia; India</meaning>
+			<kun>しるし</kun>
+			<on>イン</on>
+			<kun>しる・す</kun>
+		</kanji>
+		<kanji>
+			<char>栄</char>
+			<meaning>Prosper; Flourish; Glory</meaning>
+			<on>ヨウ</on>
+			<kun>は・える</kun>
+			<kun>え</kun>
+			<on>エイ</on>
+			<kun>さか・える</kun>
+			<kun>は・え</kun>
+		</kanji>
+		<kanji>
+			<char>英</char>
+			<meaning>England; Excellence; Glory</meaning>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>塩</char>
+			<meaning>Salt</meaning>
+			<kun>しお</kun>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>億</char>
+			<meaning>Hundred million</meaning>
+			<on>オク</on>
+		</kanji>
+		<kanji>
+			<char>加</char>
+			<meaning>Add; Append</meaning>
+			<kun>くわ・える</kun>
+			<on>カ</on>
+			<kun>くわ・わる</kun>
+		</kanji>
+		<kanji>
+			<char>果</char>
+			<meaning>End; Reward; Fruit</meaning>
+			<kun>は・てる</kun>
+			<kun>は・て</kun>
+			<on>カ</on>
+			<kun>はた・す</kun>
+		</kanji>
+		<kanji>
+			<char>課</char>
+			<meaning>Impose; Section of company; Chapter of book</meaning>
+			<kun>か・す</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>貨</char>
+			<meaning>Currency; Coinage; Goods</meaning>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>芽</char>
+			<meaning>Sprout; Bud; Germinate</meaning>
+			<kun>め</kun>
+			<on>ガ</on>
+			<kun>め・ぐむ</kun>
+		</kanji>
+		<kanji>
+			<char>改</char>
+			<meaning>Renew; Revise; Reform</meaning>
+			<kun>あらた・める</kun>
+			<on>カイ</on>
+			<kun>あらた・まる</kun>
+		</kanji>
+		<kanji>
+			<char>械</char>
+			<meaning>Appliance; Machinery; Shackles</meaning>
+			<kun>かせ</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>害</char>
+			<meaning>Damage; Harm; Infringement</meaning>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>街</char>
+			<meaning>District; Town; Road</meaning>
+			<on>カイ</on>
+			<on>ガイ</on>
+			<kun>まち</kun>
+		</kanji>
+		<kanji>
+			<char>各</char>
+			<meaning>Each; Every</meaning>
+			<kun>おのおの</kun>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>覚</char>
+			<meaning>Remember; Wake up; Senses</meaning>
+			<kun>おぼ・える</kun>
+			<kun>さ・ます</kun>
+			<on>カク</on>
+			<kun>さ・める</kun>
+			<kun>さと・る</kun>
+		</kanji>
+		<kanji>
+			<char>完</char>
+			<meaning>Complete; Perfect; Ended</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>官</char>
+			<meaning>Official; Officer</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>管</char>
+			<meaning>Pipe; Tube; Jurisdiction</meaning>
+			<kun>くだ</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>観</char>
+			<meaning>View; Observe; Viewpoint</meaning>
+			<kun>み・る</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>関</char>
+			<meaning>Concern with; Barrier; Agency</meaning>
+			<kun>せき</kun>
+			<on>カン</on>
+			<kun>かか・わる</kun>
+		</kanji>
+		<kanji>
+			<char>願</char>
+			<meaning>Wish for; Entreaty; Pray</meaning>
+			<kun>ねが・う</kun>
+			<on>ガン</on>
+		</kanji>
+		<kanji>
+			<char>喜</char>
+			<meaning>Be delighted; Joy</meaning>
+			<kun>よろこ・ぶ</kun>
+			<on>キ</on>
+			<kun>よろこ・ばす</kun>
+		</kanji>
+		<kanji>
+			<char>器</char>
+			<meaning>Container; Device; Utility</meaning>
+			<kun>うつわ</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>希</char>
+			<meaning>Rare; Dilute; Hope</meaning>
+			<on>ケ</on>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>旗</char>
+			<meaning>Flag; Ensign</meaning>
+			<kun>はた</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>機</char>
+			<meaning>Machine; Mechanism; Loom</meaning>
+			<kun>はた</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>季</char>
+			<meaning>Season</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>紀</char>
+			<meaning>Era; Century</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>議</char>
+			<meaning>Opinion; Debate; Discussion</meaning>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>救</char>
+			<meaning>Save; Rescue</meaning>
+			<kun>すく・う</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>求</char>
+			<meaning>Seek after; Inquire; Claim</meaning>
+			<on>グ</on>
+			<on>キュウ</on>
+			<kun>もと・める</kun>
+		</kanji>
+		<kanji>
+			<char>泣</char>
+			<meaning>Cry; Weep</meaning>
+			<kun>な・く</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>給</char>
+			<meaning>Bestow; Wages; Supply</meaning>
+			<kun>たま・う</kun>
+			<on>キュウ</on>
+			<kun>たも・う</kun>
+		</kanji>
+		<kanji>
+			<char>挙</char>
+			<meaning>Prosper; Be captured; Raise</meaning>
+			<kun>あ・げる</kun>
+			<kun>こぞ・る</kun>
+			<on>キョ</on>
+			<kun>あ・がる</kun>
+		</kanji>
+		<kanji>
+			<char>漁</char>
+			<meaning>Fish for</meaning>
+			<on>リョウ</on>
+			<on>ギョ</on>
+			<kun>あさ・る</kun>
+		</kanji>
+		<kanji>
+			<char>競</char>
+			<meaning>Compete with; Contend with; Race</meaning>
+			<on>キョウ</on>
+			<kun>せ・る</kun>
+			<on>ケイ</on>
+			<kun>きそ・う</kun>
+		</kanji>
+		<kanji>
+			<char>共</char>
+			<meaning>Together with; Mutual; Co-</meaning>
+			<kun>とも</kun>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>協</char>
+			<meaning>Cooperation; Collaboration</meaning>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>鏡</char>
+			<meaning>Mirror; Reflection</meaning>
+			<on>キョウ</on>
+			<on>ケイ</on>
+			<kun>かがみ</kun>
+		</kanji>
+		<kanji>
+			<char>極</char>
+			<meaning>Investigate thoroughly; Reach an end; Extremes</meaning>
+			<on>ゴク</on>
+			<kun>きわ・まる</kun>
+			<kun>き・まる</kun>
+			<on>キョク</on>
+			<kun>きわ・める</kun>
+			<kun>き・める</kun>
+		</kanji>
+		<kanji>
+			<char>訓</char>
+			<meaning>Precepts; Instructions; Japanese reading of Kanji</meaning>
+			<kun>くん・ずる</kun>
+			<on>クン</on>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>軍</char>
+			<meaning>Army; War</meaning>
+			<on>グン</on>
+			<kun>いくさ</kun>
+		</kanji>
+		<kanji>
+			<char>郡</char>
+			<meaning>County; District</meaning>
+			<on>グン</on>
+		</kanji>
+		<kanji>
+			<char>型</char>
+			<meaning>Model; Type; Pattern</meaning>
+			<kun>かた</kun>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>径</char>
+			<meaning>Diameter; Path</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>景</char>
+			<meaning>Scene; View</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>芸</char>
+			<meaning>Arts; Craft</meaning>
+			<on>ゲイ</on>
+		</kanji>
+		<kanji>
+			<char>欠</char>
+			<meaning>Absence; Defect; Gap</meaning>
+			<kun>か・く</kun>
+			<kun>か・かす</kun>
+			<on>ケツ</on>
+			<kun>か・ける</kun>
+		</kanji>
+		<kanji>
+			<char>結</char>
+			<meaning>Bind; Link together; Conclude</meaning>
+			<on>ケチ</on>
+			<kun>ゆ・う</kun>
+			<on>ケツ</on>
+			<kun>むす・ぶ</kun>
+			<kun>ゆ・わえる</kun>
+		</kanji>
+		<kanji>
+			<char>健</char>
+			<meaning>Vigourous; Healthy</meaning>
+			<kun>すこ・やか</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>建</char>
+			<meaning>Erect; Construct; Found</meaning>
+			<on>コン</on>
+			<kun>た・てる</kun>
+			<on>ケン</on>
+			<kun>た・つ</kun>
+		</kanji>
+		<kanji>
+			<char>験</char>
+			<meaning>Test; Examine; Assay</meaning>
+			<kun>ため・す</kun>
+			<on>ゲン</on>
+			<on>ケン</on>
+			<kun>ため・し</kun>
+		</kanji>
+		<kanji>
+			<char>固</char>
+			<meaning>Solidify; Harden; Resolve</meaning>
+			<kun>かた・い</kun>
+			<kun>かた・まる</kun>
+			<on>コ</on>
+			<kun>かた・める</kun>
+		</kanji>
+		<kanji>
+			<char>候</char>
+			<meaning>Weather; Season</meaning>
+			<kun>そうろう</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>功</char>
+			<meaning>Merit; Efficacy; Exploits</meaning>
+			<on>ク</on>
+			<on>コウ</on>
+			<kun>いさお</kun>
+		</kanji>
+		<kanji>
+			<char>好</char>
+			<meaning>Prefer; Like; Good</meaning>
+			<kun>この・む</kun>
+			<kun>す・く</kun>
+			<kun>い・い</kun>
+			<on>コウ</on>
+			<kun>す・き</kun>
+			<kun>よ・い</kun>
+		</kanji>
+		<kanji>
+			<char>康</char>
+			<meaning>Healthy; Peaceful</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>航</char>
+			<meaning>Sailing; Voyage</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>告</char>
+			<meaning>Inform; Advise; Admonish</meaning>
+			<kun>つ・げる</kun>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>差</char>
+			<meaning>Stretch out; Difference; Variation</meaning>
+			<kun>さ・す</kun>
+			<on>サ</on>
+			<kun>さ・し</kun>
+		</kanji>
+		<kanji>
+			<char>最</char>
+			<meaning>Most; Maximum</meaning>
+			<kun>もっと・も</kun>
+			<on>サイ</on>
+			<kun>も</kun>
+		</kanji>
+		<kanji>
+			<char>菜</char>
+			<meaning>Vegetables; Greens</meaning>
+			<on>サイ</on>
+			<kun>な</kun>
+		</kanji>
+		<kanji>
+			<char>材</char>
+			<meaning>Timber; Material; Talent</meaning>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>昨</char>
+			<meaning>The previous</meaning>
+			<on>サク</on>
+		</kanji>
+		<kanji>
+			<char>刷</char>
+			<meaning>Print; Publish</meaning>
+			<kun>す・る</kun>
+			<on>サツ</on>
+		</kanji>
+		<kanji>
+			<char>察</char>
+			<meaning>Guess; Investigate; Patrol</meaning>
+			<on>サツ</on>
+		</kanji>
+		<kanji>
+			<char>札</char>
+			<meaning>Label; Tag; Note</meaning>
+			<kun>ふだ</kun>
+			<on>サツ</on>
+		</kanji>
+		<kanji>
+			<char>殺</char>
+			<meaning>Kill; Obliterate</meaning>
+			<kun>ころ・す</kun>
+			<on>サっ</on>
+			<kun>そ・ぐ</kun>
+			<on>セっ</on>
+			<on>サツ</on>
+			<kun>ころ・し</kun>
+			<on>サイ</on>
+			<on>セツ</on>
+		</kanji>
+		<kanji>
+			<char>参</char>
+			<meaning>Come; Visit</meaning>
+			<kun>まい・る</kun>
+			<on>ジン</on>
+			<on>サン</on>
+			<on>ザン</on>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>散</char>
+			<meaning>Scatter; Diffuse; Unravel</meaning>
+			<kun>ち・る</kun>
+			<kun>ち・らかす</kun>
+			<kun>ばら</kun>
+			<on>サン</on>
+			<kun>ち・らす</kun>
+			<kun>ばら・ける</kun>
+			<kun>ち・らかる</kun>
+		</kanji>
+		<kanji>
+			<char>産</char>
+			<meaning>Give birth; Produce</meaning>
+			<kun>う・む</kun>
+			<kun>うぶ</kun>
+			<on>サン</on>
+			<kun>う・まれる</kun>
+			<kun>む・す</kun>
+		</kanji>
+		<kanji>
+			<char>残</char>
+			<meaning>Remain; Leave behind; Detain</meaning>
+			<on>サン</on>
+			<kun>のこ・す</kun>
+			<on>ザン</on>
+			<kun>のこ・る</kun>
+			<kun>のこ・り</kun>
+		</kanji>
+		<kanji>
+			<char>司</char>
+			<meaning>Rule; Administer; Commandant</meaning>
+			<kun>つかさど・る</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>史</char>
+			<meaning>History; Chronicle</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>士</char>
+			<meaning>Distinguished person; Gentleman</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>氏</char>
+			<meaning>Family name; Lineage; Mr.</meaning>
+			<kun>うじ</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>試</char>
+			<meaning>Test; Try out; Specimen</meaning>
+			<kun>こころ・みる</kun>
+			<on>シ</on>
+			<kun>ため・す</kun>
+		</kanji>
+		<kanji>
+			<char>児</char>
+			<meaning>Child; Offspring; Youth</meaning>
+			<on>ニ</on>
+			<kun>ご</kun>
+			<on>ジ</on>
+			<kun>こ</kun>
+		</kanji>
+		<kanji>
+			<char>治</char>
+			<meaning>Cure; Govern; Be at peace</meaning>
+			<on>チ</on>
+			<kun>おさ・まる</kun>
+			<kun>なお・す</kun>
+			<on>ジ</on>
+			<kun>おさ・める</kun>
+			<kun>なお・る</kun>
+		</kanji>
+		<kanji>
+			<char>辞</char>
+			<meaning>Retire; Resign; Word</meaning>
+			<kun>や・める</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>失</char>
+			<meaning>Lose; Disappear; Disqualify</meaning>
+			<kun>うしな・う</kun>
+			<on>シツ</on>
+			<kun>う・せる</kun>
+		</kanji>
+		<kanji>
+			<char>借</char>
+			<meaning>Loan; Borrow; Hire</meaning>
+			<kun>か・りる</kun>
+			<on>シャク</on>
+		</kanji>
+		<kanji>
+			<char>種</char>
+			<meaning>Seed; Variety</meaning>
+			<kun>たね</kun>
+			<kun>くさ</kun>
+			<on>シュ</on>
+			<kun>ぐさ</kun>
+		</kanji>
+		<kanji>
+			<char>周</char>
+			<meaning>Circuit; Lap; Surroundings</meaning>
+			<kun>まわ・り</kun>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>祝</char>
+			<meaning>Congratulate; Festivity</meaning>
+			<on>シュウ</on>
+			<on>シュク</on>
+			<kun>いわ・う</kun>
+		</kanji>
+		<kanji>
+			<char>順</char>
+			<meaning>Turn; Sequence; Obedience</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>初</char>
+			<meaning>Begin; First</meaning>
+			<kun>はじ・め</kun>
+			<kun>はじ・めまして</kun>
+			<kun>うい</kun>
+			<on>ショ</on>
+			<kun>はじ・めて</kun>
+			<kun>はつ</kun>
+			<kun>そ・める</kun>
+		</kanji>
+		<kanji>
+			<char>唱</char>
+			<meaning>Recite; Chant; Sing</meaning>
+			<kun>とな・える</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>松</char>
+			<meaning>Pine tree</meaning>
+			<kun>まつ</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>焼</char>
+			<meaning>Burn; Bake; Grill</meaning>
+			<kun>や・く</kun>
+			<kun>や・き</kun>
+			<on>ショウ</on>
+			<kun>や・ける</kun>
+		</kanji>
+		<kanji>
+			<char>照</char>
+			<meaning>Shine upon; Illuminate; Feel shy</meaning>
+			<kun>て・る</kun>
+			<kun>て・れる</kun>
+			<on>ショウ</on>
+			<kun>て・らす</kun>
+		</kanji>
+		<kanji>
+			<char>省</char>
+			<meaning>Omit; Reflect; Ministry</meaning>
+			<on>ショウ</on>
+			<kun>はぶ・く</kun>
+			<on>セイ</on>
+			<kun>かえり・みる</kun>
+		</kanji>
+		<kanji>
+			<char>笑</char>
+			<meaning>Smile; Laugh</meaning>
+			<kun>わら・う</kun>
+			<on>ショウ</on>
+			<kun>え・む</kun>
+		</kanji>
+		<kanji>
+			<char>象</char>
+			<meaning>Elephant; Model on; Symbol</meaning>
+			<on>ゾウ</on>
+			<on>ショウ</on>
+			<kun>かたど・る</kun>
+		</kanji>
+		<kanji>
+			<char>賞</char>
+			<meaning>Reward; Prize</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>信</char>
+			<meaning>Believe; Truth; Transmission</meaning>
+			<kun>まこと</kun>
+			<kun>しん・ずる</kun>
+			<on>シン</on>
+			<kun>しん・じる</kun>
+		</kanji>
+		<kanji>
+			<char>臣</char>
+			<meaning>Retainer; Subject</meaning>
+			<on>ジン</on>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>成</char>
+			<meaning>Become; Turn into</meaning>
+			<on>ジョウ</on>
+			<kun>な・す</kun>
+			<on>セイ</on>
+			<kun>な・る</kun>
+		</kanji>
+		<kanji>
+			<char>清</char>
+			<meaning>Purify; Clear; Chaste</meaning>
+			<on>ショウ</on>
+			<kun>きよ・める</kun>
+			<on>シン</on>
+			<on>セイ</on>
+			<kun>きよ・い</kun>
+			<kun>きよ・らか</kun>
+			<kun>きよ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>静</char>
+			<meaning>Appease; Calm; Peace</meaning>
+			<on>ジョウ</on>
+			<kun>しず・める</kun>
+			<kun>しず・けさ</kun>
+			<on>セイ</on>
+			<kun>しず・か</kun>
+			<kun>しず</kun>
+			<kun>しず・まる</kun>
+		</kanji>
+		<kanji>
+			<char>席</char>
+			<meaning>Seat</meaning>
+			<kun>むしろ</kun>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>積</char>
+			<meaning>Intend; Pile up; Load goods</meaning>
+			<kun>つ・もる</kun>
+			<kun>つ・む</kun>
+			<kun>つみ</kun>
+			<on>セキ</on>
+			<kun>つ・もり</kun>
+			<kun>つ・み</kun>
+			<on>セっ</on>
+		</kanji>
+		<kanji>
+			<char>折</char>
+			<meaning>Fold; Break; Opportunity</meaning>
+			<kun>お・る</kun>
+			<kun>お・れる</kun>
+			<on>セツ</on>
+			<kun>おり</kun>
+			<kun>お・り</kun>
+		</kanji>
+		<kanji>
+			<char>節</char>
+			<meaning>Node; Tune; Occasion</meaning>
+			<on>セチ</on>
+			<on>セツ</on>
+			<kun>ふし</kun>
+		</kanji>
+		<kanji>
+			<char>説</char>
+			<meaning>Explain; Advocate; Theory</meaning>
+			<on>ゼイ</on>
+			<on>セツ</on>
+			<kun>と・く</kun>
+		</kanji>
+		<kanji>
+			<char>戦</char>
+			<meaning>Fight; Bout; War</meaning>
+			<kun>いくさ</kun>
+			<kun>おのの・く</kun>
+			<kun>たたか・い</kun>
+			<on>セン</on>
+			<kun>たたか・う</kun>
+			<kun>そよ・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>浅</char>
+			<meaning>Shallow; Pale; Miserable</meaning>
+			<on>セン</on>
+			<kun>あさ・ましい</kun>
+			<kun>あさ・い</kun>
+		</kanji>
+		<kanji>
+			<char>選</char>
+			<meaning>Choose; Elect</meaning>
+			<kun>えら・ぶ</kun>
+			<kun>よ・る</kun>
+			<on>セン</on>
+			<kun>え・る</kun>
+		</kanji>
+		<kanji>
+			<char>然</char>
+			<meaning>However; As is; A certain</meaning>
+			<on>ネン</on>
+			<kun>しか・も</kun>
+			<kun>しか・る</kun>
+			<on>ゼン</on>
+			<kun>しか・し</kun>
+			<kun>さ</kun>
+			<kun>さ・も</kun>
+		</kanji>
+		<kanji>
+			<char>倉</char>
+			<meaning>Warehouse; Granary; Magazine</meaning>
+			<kun>くら</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>巣</char>
+			<meaning>Build a nest; Hive; Den</meaning>
+			<kun>す</kun>
+			<on>ソウ</on>
+			<kun>す・くう</kun>
+		</kanji>
+		<kanji>
+			<char>争</char>
+			<meaning>Struggle; Conflict</meaning>
+			<kun>あらそ・う</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>側</char>
+			<meaning>Lean over; One side; Indistinct</meaning>
+			<kun>がわ</kun>
+			<kun>かわ</kun>
+			<kun>かたわら</kun>
+			<kun>そば・める</kun>
+			<kun>ほの・か</kun>
+			<on>ソク</on>
+			<kun>そば</kun>
+			<on>ソっ</on>
+			<kun>そば・む</kun>
+			<kun>はた</kun>
+		</kanji>
+		<kanji>
+			<char>束</char>
+			<meaning>Tie in bundle; Control; Sheaf</meaning>
+			<kun>たば</kun>
+			<kun>たば・ね</kun>
+			<kun>つか・ねる</kun>
+			<on>ソク</on>
+			<kun>たば・ねる</kun>
+			<kun>つか</kun>
+		</kanji>
+		<kanji>
+			<char>続</char>
+			<meaning>Continue; Follow; Persist</meaning>
+			<kun>つづ・ける</kun>
+			<on>ゾっ</on>
+			<kun>つづ・く</kun>
+			<on>ゾク</on>
+		</kanji>
+		<kanji>
+			<char>卒</char>
+			<meaning>Graduate; Pass away; Soldier</meaning>
+			<kun>そ・する</kun>
+			<on>シュっ</on>
+			<on>ソツ</on>
+			<on>シュツ</on>
+			<on>ソっ</on>
+		</kanji>
+		<kanji>
+			<char>孫</char>
+			<meaning>Grandchild; Descendant</meaning>
+			<kun>まご</kun>
+			<on>ソン</on>
+		</kanji>
+		<kanji>
+			<char>帯</char>
+			<meaning>Wear; Belt; Zone</meaning>
+			<kun>おび</kun>
+			<on>タイ</on>
+			<kun>お・びる</kun>
+		</kanji>
+		<kanji>
+			<char>隊</char>
+			<meaning>Troops; Squadron; Corps</meaning>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>達</char>
+			<meaning>Get to; Skillful; Plural</meaning>
+			<on>タツ</on>
+			<on>タっ</on>
+			<on>タチ</on>
+			<kun>た・する</kun>
+		</kanji>
+		<kanji>
+			<char>単</char>
+			<meaning>Simple; Single; Mono</meaning>
+			<kun>ひとえ</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>置</char>
+			<meaning>Set down; Set aside; Every other</meaning>
+			<kun>お・く</kun>
+			<on>チ</on>
+		</kanji>
+		<kanji>
+			<char>仲</char>
+			<meaning>Relashionship; Accord; Between</meaning>
+			<kun>なか</kun>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>貯</char>
+			<meaning>Stock; Store; Save</meaning>
+			<kun>たくわ・える</kun>
+			<on>チョ</on>
+		</kanji>
+		<kanji>
+			<char>兆</char>
+			<meaning>Show signs; Omens; Multitude</meaning>
+			<kun>きざ・す</kun>
+			<on>チョウ</on>
+			<kun>きざ・し</kun>
+		</kanji>
+		<kanji>
+			<char>腸</char>
+			<meaning>Intestines; Guts</meaning>
+			<kun>はらわた</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>低</char>
+			<meaning>Lower; Low down; Softly</meaning>
+			<kun>ひく・い</kun>
+			<kun>ひく・まる</kun>
+			<on>テイ</on>
+			<kun>ひく・める</kun>
+		</kanji>
+		<kanji>
+			<char>停</char>
+			<meaning>Stop; Suspend; Cease</meaning>
+			<kun>と・める</kun>
+			<on>テイ</on>
+			<kun>と・まる</kun>
+		</kanji>
+		<kanji>
+			<char>底</char>
+			<meaning>Bottom; Base; Depths</meaning>
+			<kun>そこ</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>的</char>
+			<meaning>Target; -Like; -Ary</meaning>
+			<kun>まと</kun>
+			<on>テキ</on>
+		</kanji>
+		<kanji>
+			<char>典</char>
+			<meaning>Ceremony; Scripture; Law</meaning>
+			<kun>のり</kun>
+			<on>テン</on>
+			<on>デン</on>
+		</kanji>
+		<kanji>
+			<char>伝</char>
+			<meaning>Transmit; Tradition; Legend</meaning>
+			<kun>つた・える</kun>
+			<kun>つた・う</kun>
+			<kun>づて</kun>
+			<on>デン</on>
+			<kun>つた・わる</kun>
+			<kun>つた・え</kun>
+			<kun>つて</kun>
+		</kanji>
+		<kanji>
+			<char>徒</char>
+			<meaning>Disciple; Frivolous; Gang</meaning>
+			<kun>いたずら</kun>
+			<kun>ただ</kun>
+			<on>ト</on>
+			<kun>あで</kun>
+		</kanji>
+		<kanji>
+			<char>努</char>
+			<meaning>Make effort; Hard work</meaning>
+			<kun>つと・める</kun>
+			<on>ド</on>
+		</kanji>
+		<kanji>
+			<char>灯</char>
+			<meaning>Light a fire; Lamp; Light</meaning>
+			<kun>ひ</kun>
+			<kun>ともしび</kun>
+			<kun>ほ</kun>
+			<on>トウ</on>
+			<kun>とも・す</kun>
+			<kun>さ・す</kun>
+		</kanji>
+		<kanji>
+			<char>働</char>
+			<meaning>Work; Labour</meaning>
+			<kun>はたら・く</kun>
+			<on>ドウ</on>
+			<kun>はたら・き</kun>
+		</kanji>
+		<kanji>
+			<char>堂</char>
+			<meaning>Hall; Chapel; Temple</meaning>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>得</char>
+			<meaning>Obtain; Acquire</meaning>
+			<kun>え・る</kun>
+			<on>トク</on>
+			<kun>う・る</kun>
+		</kanji>
+		<kanji>
+			<char>特</char>
+			<meaning>Special; Particular; Extra</meaning>
+			<on>トク</on>
+		</kanji>
+		<kanji>
+			<char>毒</char>
+			<meaning>Poison; Venom</meaning>
+			<on>ドク</on>
+		</kanji>
+		<kanji>
+			<char>熱</char>
+			<meaning>Hot; Fever; Thermal</meaning>
+			<kun>あつ・い</kun>
+			<on>ネツ</on>
+		</kanji>
+		<kanji>
+			<char>念</char>
+			<meaning>Keep in mind; Thought; Idea</meaning>
+			<kun>ねん・じる</kun>
+			<on>ネン</on>
+			<kun>ねん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>敗</char>
+			<meaning>Defeat; Lose</meaning>
+			<kun>やぶ・れる</kun>
+			<on>ハイ</on>
+			<kun>やぶ・る</kun>
+		</kanji>
+		<kanji>
+			<char>梅</char>
+			<meaning>Plum tree</meaning>
+			<kun>うめ</kun>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>博</char>
+			<meaning>Accomplished; Professor; Doctor</meaning>
+			<on>バク</on>
+			<on>ハク</on>
+		</kanji>
+		<kanji>
+			<char>飯</char>
+			<meaning>Food; Meal; Boiled rice</meaning>
+			<kun>めし</kun>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>費</char>
+			<meaning>Cost; Fee; Expenditure</meaning>
+			<kun>つい・える</kun>
+			<on>ヒ</on>
+			<kun>つい・やす</kun>
+		</kanji>
+		<kanji>
+			<char>飛</char>
+			<meaning>Fly; Jump; Leap</meaning>
+			<kun>と・ぶ</kun>
+			<on>ヒ</on>
+			<kun>と・ばす</kun>
+		</kanji>
+		<kanji>
+			<char>必</char>
+			<meaning>Without fail; Certainly; Inevitable</meaning>
+			<kun>かなら・ず</kun>
+			<on>ヒツ</on>
+			<on>ヒっ</on>
+		</kanji>
+		<kanji>
+			<char>標</char>
+			<meaning>Signpost; Index; Coordinate</meaning>
+			<kun>しるし</kun>
+			<on>ヒョウ</on>
+			<kun>しるべ</kun>
+		</kanji>
+		<kanji>
+			<char>票</char>
+			<meaning>Slip; Voucher; Ballot</meaning>
+			<on>ヒョウ</on>
+		</kanji>
+		<kanji>
+			<char>不</char>
+			<meaning>Non-; Un-</meaning>
+			<on>ブ</on>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>付</char>
+			<meaning>Attach; Stick to; Adhere</meaning>
+			<kun>つ・く</kun>
+			<on>フ</on>
+			<kun>つ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>夫</char>
+			<meaning>Husband; Labourer; Each</meaning>
+			<on>フウ</on>
+			<on>ブ</on>
+			<kun>そ・れ</kun>
+			<on>フ</on>
+			<kun>おっと</kun>
+			<on>プ</on>
+		</kanji>
+		<kanji>
+			<char>府</char>
+			<meaning>Prefecture; Establishment</meaning>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>副</char>
+			<meaning>Accompany; Auxiliary; Secondary</meaning>
+			<kun>そ・う</kun>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>粉</char>
+			<meaning>Powder; Dust; Flour</meaning>
+			<kun>こ</kun>
+			<on>フン</on>
+			<kun>こな</kun>
+		</kanji>
+		<kanji>
+			<char>兵</char>
+			<meaning>Soldier; Troops; Forces</meaning>
+			<kun>つわもの</kun>
+			<on>ヘイ</on>
+			<on>ヒョウ</on>
+		</kanji>
+		<kanji>
+			<char>別</char>
+			<meaning>Part from; Separate; Discern</meaning>
+			<kun>わ・ける</kun>
+			<on>ベツ</on>
+			<kun>わか・れる</kun>
+		</kanji>
+		<kanji>
+			<char>変</char>
+			<meaning>Change; Alter; Unusual</meaning>
+			<kun>か・える</kun>
+			<kun>へん・じる</kun>
+			<on>ヘン</on>
+			<kun>かわ・る</kun>
+			<kun>へん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>辺</char>
+			<meaning>Vicinity; Area</meaning>
+			<kun>あた・り</kun>
+			<on>ヘン</on>
+			<kun>ほとり</kun>
+		</kanji>
+		<kanji>
+			<char>便</char>
+			<meaning>Tidings; Post; Convenience</meaning>
+			<on>ビン</on>
+			<on>ベン</on>
+			<kun>たよ・り</kun>
+		</kanji>
+		<kanji>
+			<char>包</char>
+			<meaning>Engulf; Wrap</meaning>
+			<kun>つつ・む</kun>
+			<on>ホウ</on>
+			<kun>くる・む</kun>
+		</kanji>
+		<kanji>
+			<char>法</char>
+			<meaning>Law; Rule; Principle</meaning>
+			<kun>のり</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>望</char>
+			<meaning>Hope; Desire; Outlook</meaning>
+			<on>モウ</on>
+			<kun>のぞ・み</kun>
+			<on>ボウ</on>
+			<kun>のぞ・む</kun>
+			<kun>もち</kun>
+		</kanji>
+		<kanji>
+			<char>牧</char>
+			<meaning>Herding; Pasture; Meadow</meaning>
+			<kun>まき</kun>
+			<on>ボク</on>
+		</kanji>
+		<kanji>
+			<char>末</char>
+			<meaning>Tip; End; Conslusion</meaning>
+			<kun>すえ</kun>
+			<kun>うら</kun>
+			<on>マツ</on>
+			<on>バツ</on>
+			<kun>うれ</kun>
+		</kanji>
+		<kanji>
+			<char>満</char>
+			<meaning>Fill; Satisfy</meaning>
+			<on>バン</on>
+			<kun>み・たす</kun>
+			<on>マン</on>
+			<kun>み・ちる</kun>
+			<kun>み・つ</kun>
+		</kanji>
+		<kanji>
+			<char>未</char>
+			<meaning>Not yet; Still</meaning>
+			<kun>ま・だ</kun>
+			<kun>ひつじ</kun>
+			<on>ミ</on>
+			<kun>いま・だ</kun>
+		</kanji>
+		<kanji>
+			<char>脈</char>
+			<meaning>Vein; Pulse; Mountain range</meaning>
+			<kun>すじ</kun>
+			<on>ミャク</on>
+		</kanji>
+		<kanji>
+			<char>民</char>
+			<meaning>The people; Populace</meaning>
+			<kun>たみ</kun>
+			<on>ミン</on>
+		</kanji>
+		<kanji>
+			<char>無</char>
+			<meaning>Not; None; Lose</meaning>
+			<on>ブ</on>
+			<kun>な・くす</kun>
+			<on>ム</on>
+			<kun>な・い</kun>
+		</kanji>
+		<kanji>
+			<char>約</char>
+			<meaning>Contract; Agreement; Approximately</meaning>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>勇</char>
+			<meaning>Be enthusiastic; Courage; Gallantry</meaning>
+			<kun>いさ・む</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>要</char>
+			<meaning>Require; The point; Essential</meaning>
+			<kun>い・る</kun>
+			<on>ヨウ</on>
+			<kun>かなめ</kun>
+		</kanji>
+		<kanji>
+			<char>養</char>
+			<meaning>Rear; Cultivate; Bring up</meaning>
+			<kun>やしな・う</kun>
+			<on>ヨウ</on>
+			<kun>やしな・い</kun>
+		</kanji>
+		<kanji>
+			<char>浴</char>
+			<meaning>Bathe; Wash; Pour upon</meaning>
+			<kun>あ・びる</kun>
+			<on>ヨク</on>
+			<kun>あ・びせる</kun>
+		</kanji>
+		<kanji>
+			<char>利</char>
+			<meaning>Be effective; Profit; Interest</meaning>
+			<kun>き・く</kun>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>陸</char>
+			<meaning>Continent; Land</meaning>
+			<on>ロク</on>
+			<on>リク</on>
+			<kun>おか</kun>
+		</kanji>
+		<kanji>
+			<char>料</char>
+			<meaning>fee;materials</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>良</char>
+			<meaning>Good; Well</meaning>
+			<kun>よ・い</kun>
+			<on>リョウ</on>
+			<kun>い・い</kun>
+		</kanji>
+		<kanji>
+			<char>量</char>
+			<meaning>Amount; Volume; Quantity</meaning>
+			<kun>はか・る</kun>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>輪</char>
+			<meaning>Ring; Wheel; Cycle</meaning>
+			<kun>わ</kun>
+			<on>リン</on>
+		</kanji>
+		<kanji>
+			<char>類</char>
+			<meaning>Sort; Kind; Variety</meaning>
+			<kun>たぐ・い</kun>
+			<on>ルイ</on>
+		</kanji>
+		<kanji>
+			<char>令</char>
+			<meaning>Command; Relation</meaning>
+			<kun>し・む</kun>
+			<on>レイ</on>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>例</char>
+			<meaning>Illustrate; Compare; Example</meaning>
+			<kun>たと・える</kun>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>冷</char>
+			<meaning>Cool down; Cold; Chilly</meaning>
+			<kun>ひ・える</kun>
+			<kun>つめ・たい</kun>
+			<kun>さ・ます</kun>
+			<on>レイ</on>
+			<kun>ひ・やす</kun>
+			<kun>さ・める</kun>
+		</kanji>
+		<kanji>
+			<char>歴</char>
+			<meaning>Successive; Curriculum</meaning>
+			<on>レキ</on>
+		</kanji>
+		<kanji>
+			<char>連</char>
+			<meaning>Link together; Stretch out; Accompany</meaning>
+			<kun>つら・なる</kun>
+			<on>レン</on>
+			<kun>つら・ねる</kun>
+			<kun>つ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>労</char>
+			<meaning>Trouble; Toil; Sympathise</meaning>
+			<kun>ろう・する</kun>
+			<kun>いたず・き</kun>
+			<on>ロウ</on>
+			<kun>いたわ・る</kun>
+			<kun>ねぎら・う</kun>
+		</kanji>
+		<kanji>
+			<char>老</char>
+			<meaning>Grow old; Aged; Veteran</meaning>
+			<kun>お・いる</kun>
+			<on>ロウ</on>
+			<kun>ふ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>録</char>
+			<meaning>Record; Catalogue</meaning>
+			<on>ロク</on>
+		</kanji>
+	</category>
+	<category id="kanji_5">
+		<kanji>
+			<char>圧</char>
+			<meaning>Pressure</meaning>
+			<kun>へ・す</kun>
+			<on>アっ</on>
+			<kun>お・す</kun>
+			<on>アツ</on>
+		</kanji>
+		<kanji>
+			<char>易</char>
+			<meaning>Easy to; Simple; Divination</meaning>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>移</char>
+			<meaning>Transfer; Infect; Move on to</meaning>
+			<kun>うつ・る</kun>
+			<on>イ</on>
+			<kun>うつ・す</kun>
+		</kanji>
+		<kanji>
+			<char>因</char>
+			<meaning>Cause; Reason for; Be connected with</meaning>
+			<kun>よ・る</kun>
+			<on>イン</on>
+			<kun>ちな・む</kun>
+		</kanji>
+		<kanji>
+			<char>営</char>
+			<meaning>Manage; Oversee; Barracks</meaning>
+			<kun>いとな・む</kun>
+			<on>エイ</on>
+			<kun>いとな・み</kun>
+		</kanji>
+		<kanji>
+			<char>永</char>
+			<meaning>Eternity; Long time</meaning>
+			<kun>なが・い</kun>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>衛</char>
+			<meaning>Defense; Guard</meaning>
+			<on>エ</on>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>液</char>
+			<meaning>Secretion; Juices; Mucus</meaning>
+			<on>エキ</on>
+		</kanji>
+		<kanji>
+			<char>益</char>
+			<meaning>Profit; Increase; Benefit</meaning>
+			<on>ヤク</on>
+			<on>エキ</on>
+			<kun>ま・す</kun>
+		</kanji>
+		<kanji>
+			<char>演</char>
+			<meaning>Perform; Address</meaning>
+			<kun>えん・じる</kun>
+			<on>エン</on>
+			<kun>えん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>往</char>
+			<meaning>Let go; Go out; Sometimes</meaning>
+			<kun>ゆ・く</kun>
+			<on>オウ</on>
+			<kun>い・なす</kun>
+		</kanji>
+		<kanji>
+			<char>応</char>
+			<meaning>Reply; Reaction</meaning>
+			<kun>こた・える</kun>
+			<kun>おう・じる</kun>
+			<on>オウ</on>
+			<on>ノウ</on>
+			<kun>おう・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>恩</char>
+			<meaning>Obligation; Debt</meaning>
+			<on>オン</on>
+		</kanji>
+		<kanji>
+			<char>仮</char>
+			<meaning>Provisional; Transient</meaning>
+			<on>ケ</on>
+			<on>カ</on>
+			<kun>かり</kun>
+		</kanji>
+		<kanji>
+			<char>価</char>
+			<meaning>Price; Value</meaning>
+			<kun>あたい</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>可</char>
+			<meaning>Approval; Possibility; Must</meaning>
+			<kun>べ・く</kun>
+			<kun>べ・からず</kun>
+			<on>カ</on>
+			<kun>べ・し</kun>
+		</kanji>
+		<kanji>
+			<char>河</char>
+			<meaning>River</meaning>
+			<kun>かわ</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>過</char>
+			<meaning>Surpass; Err; Too much</meaning>
+			<kun>す・ぎる</kun>
+			<kun>あやま・つ</kun>
+			<on>カ</on>
+			<kun>す・ごす</kun>
+			<kun>あやま・ち</kun>
+		</kanji>
+		<kanji>
+			<char>賀</char>
+			<meaning>Congratulations</meaning>
+			<on>ガ</on>
+		</kanji>
+		<kanji>
+			<char>解</char>
+			<meaning>Thaw; Analyse; Fuse together</meaning>
+			<kun>と・かす</kun>
+			<kun>ほ・どく</kun>
+			<kun>ほぐ・す</kun>
+			<kun>と・ける</kun>
+			<on>ゲ</on>
+			<kun>わか・る</kun>
+			<on>カイ</on>
+			<kun>と・く</kun>
+			<kun>ほぐ・れる</kun>
+			<kun>ほど・ける</kun>
+			<kun>ほご・す</kun>
+		</kanji>
+		<kanji>
+			<char>快</char>
+			<meaning>Pleasure; Harmony</meaning>
+			<kun>こころよ・い</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>格</char>
+			<meaning>Qualification; Character</meaning>
+			<on>コウ</on>
+			<on>カク</on>
+			<on>ゴウ</on>
+		</kanji>
+		<kanji>
+			<char>確</char>
+			<meaning>Certainty; Accuracy</meaning>
+			<kun>たし・か</kun>
+			<on>カク</on>
+			<kun>たし・かめる</kun>
+		</kanji>
+		<kanji>
+			<char>額</char>
+			<meaning>Forehead; Amount; Framed picture</meaning>
+			<kun>ひたい</kun>
+			<on>ガク</on>
+		</kanji>
+		<kanji>
+			<char>刊</char>
+			<meaning>Edition; Publication</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>幹</char>
+			<meaning>Trunk; Stem; Chief</meaning>
+			<kun>みき</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>慣</char>
+			<meaning>Grow accustomed; Be familiar with</meaning>
+			<kun>な・れる</kun>
+			<on>カン</on>
+			<kun>な・らす</kun>
+		</kanji>
+		<kanji>
+			<char>眼</char>
+			<meaning>Eyeball</meaning>
+			<kun>め</kun>
+			<kun>まなこ</kun>
+			<on>ガン</on>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>基</char>
+			<meaning>Base; Foundation</meaning>
+			<kun>もとい</kun>
+			<on>キ</on>
+			<kun>もと・づく</kun>
+		</kanji>
+		<kanji>
+			<char>寄</char>
+			<meaning>Draw close; Send out; Contribute</meaning>
+			<kun>よ・る</kun>
+			<kun>よ・こす</kun>
+			<on>キ</on>
+			<kun>よ・せる</kun>
+			<kun>よ・せ</kun>
+		</kanji>
+		<kanji>
+			<char>規</char>
+			<meaning>Rules; Regular</meaning>
+			<on>ギ</on>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>技</char>
+			<meaning>Craft; Technique; Performance</meaning>
+			<kun>わざ</kun>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>義</char>
+			<meaning>System; Doctrine; Meaning</meaning>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>逆</char>
+			<meaning>Oppose; Reverse</meaning>
+			<kun>さか・さ</kun>
+			<kun>さか</kun>
+			<on>ギャク</on>
+			<kun>さか・らう</kun>
+			<on>ゲキ</on>
+		</kanji>
+		<kanji>
+			<char>久</char>
+			<meaning>Long time</meaning>
+			<kun>ひさ・しい</kun>
+			<on>キュウ</on>
+			<on>ク</on>
+		</kanji>
+		<kanji>
+			<char>旧</char>
+			<meaning>Long time ago; Former</meaning>
+			<kun>ふる・い</kun>
+			<kun>もと</kun>
+			<on>キュウ</on>
+			<kun>ふる</kun>
+		</kanji>
+		<kanji>
+			<char>居</char>
+			<meaning>Exist; Dwelling</meaning>
+			<kun>い・る</kun>
+			<kun>い</kun>
+			<on>キョ</on>
+			<kun>お・る</kun>
+		</kanji>
+		<kanji>
+			<char>許</char>
+			<meaning>Permit; Allow</meaning>
+			<kun>ゆる・す</kun>
+			<kun>もと</kun>
+			<on>キョ</on>
+			<kun>ゆる・し</kun>
+		</kanji>
+		<kanji>
+			<char>境</char>
+			<meaning>Border; Far away place</meaning>
+			<on>ケイ</on>
+			<on>キョウ</on>
+			<kun>さかい</kun>
+		</kanji>
+		<kanji>
+			<char>興</char>
+			<meaning>Spring up; Amusement; Interest</meaning>
+			<on>コウ</on>
+			<kun>おこ・す</kun>
+			<on>キョウ</on>
+			<kun>おこ・る</kun>
+		</kanji>
+		<kanji>
+			<char>均</char>
+			<meaning>Equal; Uniform; Level</meaning>
+			<kun>なら・す</kun>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>禁</char>
+			<meaning>Forbid; Confine</meaning>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>句</char>
+			<meaning>Phrase; Sentence</meaning>
+			<on>ク</on>
+		</kanji>
+		<kanji>
+			<char>群</char>
+			<meaning>Group; Herd; Shoal</meaning>
+			<kun>むら・がる</kun>
+			<kun>む・れる</kun>
+			<on>グン</on>
+			<kun>む・れ</kun>
+		</kanji>
+		<kanji>
+			<char>経</char>
+			<meaning>Elapse; Longitude; Sutra</meaning>
+			<on>キョウ</on>
+			<kun>た・つ</kun>
+			<on>ケイ</on>
+			<kun>へ・る</kun>
+		</kanji>
+		<kanji>
+			<char>潔</char>
+			<meaning>Pure; Chaste; Righteous</meaning>
+			<kun>いさぎよ・い</kun>
+			<on>ケツ</on>
+		</kanji>
+		<kanji>
+			<char>件</char>
+			<meaning>Affair; Matter</meaning>
+			<kun>くだん</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>券</char>
+			<meaning>Ticket; Certificate</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>検</char>
+			<meaning>Examine; Investigate</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>険</char>
+			<meaning>Perilous; Impregnable</meaning>
+			<on>ケン</on>
+			<kun>けわ・しい</kun>
+		</kanji>
+		<kanji>
+			<char>減</char>
+			<meaning>Decrease; Subtract; Be hungry</meaning>
+			<kun>へ・る</kun>
+			<on>ゲン</on>
+			<kun>へ・らす</kun>
+		</kanji>
+		<kanji>
+			<char>現</char>
+			<meaning>Manifest; Actuality; Display</meaning>
+			<kun>あらわ・す</kun>
+			<kun>げん・ずる</kun>
+			<on>ゲン</on>
+			<kun>あらわ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>限</char>
+			<meaning>Limit; Maximum</meaning>
+			<kun>かぎ・る</kun>
+			<on>ゲン</on>
+			<kun>かぎ・り</kun>
+		</kanji>
+		<kanji>
+			<char>個</char>
+			<meaning>Small item; Individual</meaning>
+			<on>コ</on>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>故</char>
+			<meaning>Cause; Origin; Deceased</meaning>
+			<kun>ゆえ</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>護</char>
+			<meaning>Escort; Nursing; Protection</meaning>
+			<on>ゴ</on>
+		</kanji>
+		<kanji>
+			<char>効</char>
+			<meaning>Effective; Efficient</meaning>
+			<kun>き・く</kun>
+			<on>コウ</on>
+			<kun>きき</kun>
+		</kanji>
+		<kanji>
+			<char>厚</char>
+			<meaning>Thick; Cordial</meaning>
+			<kun>あつ・い</kun>
+			<kun>あつ</kun>
+			<on>コウ</on>
+			<kun>あつ・み</kun>
+		</kanji>
+		<kanji>
+			<char>構</char>
+			<meaning>Care about; Pose; Entertain</meaning>
+			<on>コウ</on>
+			<kun>かま・う</kun>
+			<kun>かま・える</kun>
+		</kanji>
+		<kanji>
+			<char>耕</char>
+			<meaning>Plow; Cultivate</meaning>
+			<kun>たがや・す</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>講</char>
+			<meaning>Lecture; Address</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>鉱</char>
+			<meaning>Ore; Mineral</meaning>
+			<kun>あらがね</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>混</char>
+			<meaning>Mix; Be crowded</meaning>
+			<kun>ま・じる</kun>
+			<kun>ま・ぜる</kun>
+			<on>コン</on>
+			<kun>ま・ざる</kun>
+		</kanji>
+		<kanji>
+			<char>査</char>
+			<meaning>Audit; Inspect</meaning>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>再</char>
+			<meaning>Again; Repeated</meaning>
+			<kun>ふたた・び</kun>
+			<on>サイ</on>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>妻</char>
+			<meaning>Wife</meaning>
+			<kun>つま</kun>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>採</char>
+			<meaning>Extract; Gather</meaning>
+			<kun>と・る</kun>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>災</char>
+			<meaning>Calamity; Disaster</meaning>
+			<kun>わざわ・い</kun>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>際</char>
+			<meaning>On occasion of; On the edge of; Risky</meaning>
+			<kun>きわ</kun>
+			<on>サイ</on>
+			<kun>ぎわ</kun>
+		</kanji>
+		<kanji>
+			<char>在</char>
+			<meaning>Exist; Reside</meaning>
+			<kun>あ・る</kun>
+			<on>ザイ</on>
+		</kanji>
+		<kanji>
+			<char>罪</char>
+			<meaning>Crime; Sin; Offense</meaning>
+			<kun>つみ</kun>
+			<on>ザイ</on>
+		</kanji>
+		<kanji>
+			<char>財</char>
+			<meaning>Belongings; Fortune</meaning>
+			<on>サイ</on>
+			<on>ザイ</on>
+		</kanji>
+		<kanji>
+			<char>桜</char>
+			<meaning>Cherry tree</meaning>
+			<kun>さくら</kun>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>雑</char>
+			<meaning>Mix; Coarse; Intricate</meaning>
+			<kun>ま・じる</kun>
+			<on>ザ</on>
+			<on>ザツ</on>
+			<kun>ま・ざる</kun>
+			<on>ゾウ</on>
+		</kanji>
+		<kanji>
+			<char>賛</char>
+			<meaning>Commendation; Approval</meaning>
+			<on>サン</on>
+		</kanji>
+		<kanji>
+			<char>酸</char>
+			<meaning>Acid</meaning>
+			<kun>す・い</kun>
+			<on>サン</on>
+		</kanji>
+		<kanji>
+			<char>師</char>
+			<meaning>Expert; Teacher</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>志</char>
+			<meaning>Intend; Wish; Will</meaning>
+			<kun>こころざ・す</kun>
+			<on>シ</on>
+			<kun>こころざし</kun>
+		</kanji>
+		<kanji>
+			<char>支</char>
+			<meaning>Support; Expend; China</meaning>
+			<kun>ささ・える</kun>
+			<kun>か・う</kun>
+			<on>シ</on>
+			<kun>つか・える</kun>
+		</kanji>
+		<kanji>
+			<char>枝</char>
+			<meaning>Branch; Limb of tree</meaning>
+			<kun>えだ</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>資</char>
+			<meaning>Fund; Investment; Material</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>飼</char>
+			<meaning>Keep animals; Tame; Rear</meaning>
+			<kun>か・う</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>似</char>
+			<meaning>Resemble; Imitate</meaning>
+			<kun>に・る</kun>
+			<kun>に</kun>
+			<on>ジ</on>
+			<kun>に・せる</kun>
+		</kanji>
+		<kanji>
+			<char>示</char>
+			<meaning>Point at; Reveal; Present</meaning>
+			<on>シ</on>
+			<on>ジ</on>
+			<kun>しめ・す</kun>
+		</kanji>
+		<kanji>
+			<char>識</char>
+			<meaning>Weave; Incorporate; Organisation</meaning>
+			<kun>お・る</kun>
+			<on>シキ</on>
+		</kanji>
+		<kanji>
+			<char>質</char>
+			<meaning>Enquire; Substance</meaning>
+			<kun>たち</kun>
+			<on>シチ</on>
+			<on>シツ</on>
+			<kun>ただ・す</kun>
+		</kanji>
+		<kanji>
+			<char>舎</char>
+			<meaning>Building; Mansion; Dormitory</meaning>
+			<on>セキ</on>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>謝</char>
+			<meaning>Apologise; Remit; Thank</meaning>
+			<kun>あやま・る</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>授</char>
+			<meaning>Instruct; Award; Bestow</meaning>
+			<kun>さず・ける</kun>
+			<on>ジュ</on>
+			<kun>さず・かる</kun>
+		</kanji>
+		<kanji>
+			<char>修</char>
+			<meaning>Train; Study; Repair</meaning>
+			<kun>おさ・める</kun>
+			<on>シュ</on>
+			<on>シュウ</on>
+			<kun>おさ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>術</char>
+			<meaning>Technique; Art; Technology</meaning>
+			<kun>すべ</kun>
+			<on>ジュツ</on>
+		</kanji>
+		<kanji>
+			<char>述</char>
+			<meaning>Declare; State</meaning>
+			<kun>の・べる</kun>
+			<on>ジュツ</on>
+		</kanji>
+		<kanji>
+			<char>準</char>
+			<meaning>Model on; Correspond to; Level</meaning>
+			<kun>じゅん・じる</kun>
+			<kun>なぞら・える</kun>
+			<on>ジュン</on>
+			<kun>じゅん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>序</char>
+			<meaning>Order;  System; Incidental</meaning>
+			<kun>つい・で</kun>
+			<on>ジョ</on>
+		</kanji>
+		<kanji>
+			<char>承</char>
+			<meaning>Recieve; Consent; Hear</meaning>
+			<kun>うけたまわ・る</kun>
+			<on>ショウ</on>
+			<kun>う・ける</kun>
+		</kanji>
+		<kanji>
+			<char>招</char>
+			<meaning>Invite; Beckon</meaning>
+			<kun>まね・く</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>証</char>
+			<meaning>Proof; Authentication; Guarantee</meaning>
+			<kun>あかし</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>常</char>
+			<meaning>Eternal; Habitual; Normal</meaning>
+			<kun>つね</kun>
+			<kun>とわ</kun>
+			<on>ジョウ</on>
+			<kun>とこ</kun>
+		</kanji>
+		<kanji>
+			<char>情</char>
+			<meaning>Pity; Compassion</meaning>
+			<kun>なさ・け</kun>
+			<on>ゼイ</on>
+			<on>ジョウ</on>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>条</char>
+			<meaning>Stripe; Rail; Clause</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>状</char>
+			<meaning>Shaped; Request; Warrant</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>織</char>
+			<meaning>Weave; Cloth; Tissue</meaning>
+			<on>シキ</on>
+			<kun>おり</kun>
+			<on>ショク</on>
+			<kun>お・る</kun>
+		</kanji>
+		<kanji>
+			<char>職</char>
+			<meaning>Employment; Post; Occupation</meaning>
+			<on>ショク</on>
+		</kanji>
+		<kanji>
+			<char>制</char>
+			<meaning>System; Regime; Regulation</meaning>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>勢</char>
+			<meaning>Vigour; Splendour</meaning>
+			<on>ゼイ</on>
+			<kun>はず・み</kun>
+			<on>セイ</on>
+			<kun>いきお・い</kun>
+		</kanji>
+		<kanji>
+			<char>性</char>
+			<meaning>Nature; Character; Gender</meaning>
+			<on>ショウ</on>
+			<on>セイ</on>
+			<kun>さが</kun>
+		</kanji>
+		<kanji>
+			<char>政</char>
+			<meaning>Government; Rule; Politics</meaning>
+			<on>ショウ</on>
+			<on>セイ</on>
+			<kun>まつりごと</kun>
+		</kanji>
+		<kanji>
+			<char>精</char>
+			<meaning>Spirit; Character; Semen</meaning>
+			<on>ショウ</on>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>製</char>
+			<meaning>Produce of; Made of; Manufacture</meaning>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>税</char>
+			<meaning>Tax; Duty; Postage</meaning>
+			<on>ゼイ</on>
+		</kanji>
+		<kanji>
+			<char>績</char>
+			<meaning>Achievements; Record; Results</meaning>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>責</char>
+			<meaning>Blame; Reprimand</meaning>
+			<kun>せ・める</kun>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>接</char>
+			<meaning>Interview; Graft; Weld</meaning>
+			<kun>つ・ぐ</kun>
+			<on>セツ</on>
+			<kun>せ・する</kun>
+		</kanji>
+		<kanji>
+			<char>設</char>
+			<meaning>Establish; Construct</meaning>
+			<kun>もう・ける</kun>
+			<on>セツ</on>
+		</kanji>
+		<kanji>
+			<char>絶</char>
+			<meaning>Reject; Abort; Eradicate</meaning>
+			<kun>た・える</kun>
+			<kun>た・やす</kun>
+			<on>ゼツ</on>
+			<kun>た・つ</kun>
+		</kanji>
+		<kanji>
+			<char>舌</char>
+			<meaning>Tongue</meaning>
+			<kun>した</kun>
+			<on>ゼツ</on>
+		</kanji>
+		<kanji>
+			<char>銭</char>
+			<meaning>Cash; Money; 1/100 Yen</meaning>
+			<on>ゼン</on>
+			<on>セン</on>
+			<kun>ぜに</kun>
+		</kanji>
+		<kanji>
+			<char>祖</char>
+			<meaning>Ancestor; Forebear; Founder</meaning>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>素</char>
+			<meaning>Elemental; Base; Prime</meaning>
+			<on>ス</on>
+			<on>ソ</on>
+			<kun>もと</kun>
+		</kanji>
+		<kanji>
+			<char>総</char>
+			<meaning>Control; Lineage; Relationship</meaning>
+			<on>ソウ</on>
+			<kun>す・べる</kun>
+		</kanji>
+		<kanji>
+			<char>像</char>
+			<meaning>Statue; Image</meaning>
+			<on>ゾウ</on>
+		</kanji>
+		<kanji>
+			<char>増</char>
+			<meaning>Increase; Multiply; Extra</meaning>
+			<kun>ま・す</kun>
+			<kun>ふ・える</kun>
+			<kun>ま</kun>
+			<on>ゾウ</on>
+			<kun>ま・し</kun>
+			<kun>ふ・やし</kun>
+			<kun>ふ・やす</kun>
+		</kanji>
+		<kanji>
+			<char>造</char>
+			<meaning>Make; Create; Fabricate</meaning>
+			<kun>つく・る</kun>
+			<on>ゾウ</on>
+			<kun>つく・り</kun>
+		</kanji>
+		<kanji>
+			<char>則</char>
+			<meaning>Conform to; Regulation; Regular</meaning>
+			<kun>のっと・る</kun>
+			<on>ソク</on>
+		</kanji>
+		<kanji>
+			<char>測</char>
+			<meaning>Speculate; Predict; Measure</meaning>
+			<kun>はか・る</kun>
+			<on>ソク</on>
+		</kanji>
+		<kanji>
+			<char>属</char>
+			<meaning>Genus; Group</meaning>
+			<on>ショク</on>
+			<on>ゾク</on>
+		</kanji>
+		<kanji>
+			<char>損</char>
+			<meaning>Hurt; Injure; Fail</meaning>
+			<kun>そこ・なう</kun>
+			<on>ゾン</on>
+			<on>ソン</on>
+			<kun>そこ・ねる</kun>
+		</kanji>
+		<kanji>
+			<char>態</char>
+			<meaning>State of affairs; Condition; On purpose</meaning>
+			<kun>わざ・と</kun>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>貸</char>
+			<meaning>Lend; Lease; Loan</meaning>
+			<kun>か・す</kun>
+			<on>タイ</on>
+			<kun>か・し</kun>
+		</kanji>
+		<kanji>
+			<char>退</char>
+			<meaning>Retreat; Repel; Remove</meaning>
+			<kun>しりぞ・く</kun>
+			<kun>ひ・く</kun>
+			<kun>の・く</kun>
+			<on>タイ</on>
+			<kun>しりぞ・ける</kun>
+			<kun>の・ける</kun>
+			<kun>ど・く</kun>
+		</kanji>
+		<kanji>
+			<char>団</char>
+			<meaning>Body of individuals</meaning>
+			<on>トン</on>
+			<on>ダン</on>
+		</kanji>
+		<kanji>
+			<char>断</char>
+			<meaning>Refuse; Decide; Sever</meaning>
+			<kun>た・つ</kun>
+			<on>ダン</on>
+			<kun>こと・わる</kun>
+		</kanji>
+		<kanji>
+			<char>築</char>
+			<meaning>Construct; Fortify</meaning>
+			<on>チク</on>
+			<kun>きず・く</kun>
+		</kanji>
+		<kanji>
+			<char>張</char>
+			<meaning>Assert; Extend; Affix</meaning>
+			<kun>は・る</kun>
+			<kun>はり</kun>
+			<on>チョウ</on>
+			<kun>は・り</kun>
+		</kanji>
+		<kanji>
+			<char>提</char>
+			<meaning>Take along; Propose; Sue</meaning>
+			<kun>さ・げる</kun>
+			<on>チョウ</on>
+			<on>テイ</on>
+			<on>ダイ</on>
+		</kanji>
+		<kanji>
+			<char>程</char>
+			<meaning>Distance; Time ago; Extent</meaning>
+			<kun>ほど</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>敵</char>
+			<meaning>Enemy; Opponent</meaning>
+			<kun>かたき</kun>
+			<on>テキ</on>
+			<kun>かな・う</kun>
+		</kanji>
+		<kanji>
+			<char>適</char>
+			<meaning>Fit; Suit; Adapt</meaning>
+			<kun>かな・う</kun>
+			<on>テキ</on>
+		</kanji>
+		<kanji>
+			<char>統</char>
+			<meaning>Supervise; Integrate; Lineage</meaning>
+			<kun>す・べる</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>導</char>
+			<meaning>Be guided; Conduct; Introduce</meaning>
+			<kun>みちび・く</kun>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>銅</char>
+			<meaning>Copper; Bronze</meaning>
+			<kun>あかがね</kun>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>徳</char>
+			<meaning>Virtue; Morals; Charity</meaning>
+			<on>トク</on>
+		</kanji>
+		<kanji>
+			<char>独</char>
+			<meaning>Alone; Single; Independant</meaning>
+			<kun>ひと・り</kun>
+			<on>ドク</on>
+		</kanji>
+		<kanji>
+			<char>任</char>
+			<meaning>Entrust; Appointment; Post</meaning>
+			<kun>まか・す</kun>
+			<on>ニン</on>
+			<kun>まか・せる</kun>
+		</kanji>
+		<kanji>
+			<char>燃</char>
+			<meaning>Burn; Ignite; Fuel</meaning>
+			<kun>も・える</kun>
+			<kun>も・す</kun>
+			<on>ネン</on>
+			<kun>も・やす</kun>
+		</kanji>
+		<kanji>
+			<char>能</char>
+			<meaning>Function; Ability; Capacity</meaning>
+			<on>ノウ</on>
+		</kanji>
+		<kanji>
+			<char>破</char>
+			<meaning>Wear out; Destroy; Breach</meaning>
+			<kun>やぶ・る</kun>
+			<on>ハ</on>
+			<kun>やぶ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>判</char>
+			<meaning>Seal; Judgement; Become clear</meaning>
+			<on>バン</on>
+			<on>ハン</on>
+			<kun>ことわ・る</kun>
+		</kanji>
+		<kanji>
+			<char>版</char>
+			<meaning>Edition; Print; Publish</meaning>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>犯</char>
+			<meaning>Transgress; Infringe; Offend</meaning>
+			<kun>おか・す</kun>
+			<on>ハン</on>
+			<on>ボン</on>
+		</kanji>
+		<kanji>
+			<char>比</char>
+			<meaning>Compare</meaning>
+			<kun>くら・べる</kun>
+			<on>ビ</on>
+			<on>ヒ</on>
+			<kun>ひ・する</kun>
+		</kanji>
+		<kanji>
+			<char>肥</char>
+			<meaning>Fertilise; Grow fat; Manure</meaning>
+			<kun>こえ</kun>
+			<kun>こ・やす</kun>
+			<on>ヒ</on>
+			<kun>こ・える</kun>
+			<kun>こ・やし</kun>
+		</kanji>
+		<kanji>
+			<char>非</char>
+			<meaning>Wrong; Bad; Un-</meaning>
+			<kun>あら・ず</kun>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>備</char>
+			<meaning>Prepare for; Equip</meaning>
+			<kun>そな・える</kun>
+			<on>ビ</on>
+			<kun>そな・わる</kun>
+		</kanji>
+		<kanji>
+			<char>俵</char>
+			<meaning>Bale; Bag; Sack</meaning>
+			<kun>たわら</kun>
+			<on>ヒョウ</on>
+		</kanji>
+		<kanji>
+			<char>評</char>
+			<meaning>Review; Criticism; Comment</meaning>
+			<on>ヒョウ</on>
+		</kanji>
+		<kanji>
+			<char>貧</char>
+			<meaning>Poverty</meaning>
+			<on>ビン</on>
+			<on>ヒン</on>
+			<kun>まず・しい</kun>
+		</kanji>
+		<kanji>
+			<char>婦</char>
+			<meaning>Woman; Lady</meaning>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>富</char>
+			<meaning>Get rich; Fortune; Wealth</meaning>
+			<kun>とみ</kun>
+			<on>フウ</on>
+			<on>フ</on>
+			<kun>と・み</kun>
+		</kanji>
+		<kanji>
+			<char>布</char>
+			<meaning>Cloth</meaning>
+			<kun>ぬの</kun>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>武</char>
+			<meaning>Warrior; Martial</meaning>
+			<on>ム</on>
+			<on>ブ</on>
+		</kanji>
+		<kanji>
+			<char>復</char>
+			<meaning>Back at; Return to; Re-;</meaning>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>複</char>
+			<meaning>Complication; Plural; Multiple</meaning>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>仏</char>
+			<meaning>Buddha; French</meaning>
+			<on>フツ</on>
+			<on>ブツ</on>
+			<kun>ほとけ</kun>
+		</kanji>
+		<kanji>
+			<char>編</char>
+			<meaning>Knit; Compile; Part of work</meaning>
+			<kun>あ・む</kun>
+			<on>ヘン</on>
+		</kanji>
+		<kanji>
+			<char>弁</char>
+			<meaning>Dialect; Speak; Discern</meaning>
+			<kun>わきま・える</kun>
+			<on>ベン</on>
+			<kun>べん・じる</kun>
+		</kanji>
+		<kanji>
+			<char>保</char>
+			<meaning>Guarantee; Support; Preserve</meaning>
+			<kun>たも・つ</kun>
+			<on>ホ</on>
+		</kanji>
+		<kanji>
+			<char>墓</char>
+			<meaning>Grave; Tomb</meaning>
+			<kun>はか</kun>
+			<on>ボ</on>
+		</kanji>
+		<kanji>
+			<char>報</char>
+			<meaning>Reward; Recompense; Report</meaning>
+			<kun>むく・いる</kun>
+			<kun>ほう・ずる</kun>
+			<on>ホウ</on>
+			<kun>ほう・じる</kun>
+		</kanji>
+		<kanji>
+			<char>豊</char>
+			<meaning>Plentiful; Fertile</meaning>
+			<on>ホウ</on>
+			<kun>ゆた・か</kun>
+		</kanji>
+		<kanji>
+			<char>暴</char>
+			<meaning>Disclose; Run riot; Violence</meaning>
+			<on>バク</on>
+			<kun>あば・れる</kun>
+			<on>ボウ</on>
+			<kun>あば・く</kun>
+		</kanji>
+		<kanji>
+			<char>貿</char>
+			<meaning>Trade</meaning>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>防</char>
+			<meaning>Defend; Prevent</meaning>
+			<kun>ふせ・ぐ</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>務</char>
+			<meaning>Serve as; Duty; Work</meaning>
+			<kun>つと・める</kun>
+			<on>ム</on>
+		</kanji>
+		<kanji>
+			<char>夢</char>
+			<meaning>Dream</meaning>
+			<kun>ゆめ</kun>
+			<on>ム</on>
+		</kanji>
+		<kanji>
+			<char>迷</char>
+			<meaning>Dither; Stray; Get confused</meaning>
+			<kun>まよ・う</kun>
+			<on>メイ</on>
+		</kanji>
+		<kanji>
+			<char>綿</char>
+			<meaning>Cotton</meaning>
+			<kun>わた</kun>
+			<on>メン</on>
+		</kanji>
+		<kanji>
+			<char>輸</char>
+			<meaning>Transport</meaning>
+			<on>ユ</on>
+		</kanji>
+		<kanji>
+			<char>余</char>
+			<meaning>Leave over; Not much; Too much</meaning>
+			<kun>あま・る</kun>
+			<kun>あま・り</kun>
+			<on>ヨ</on>
+			<kun>あま・す</kun>
+		</kanji>
+		<kanji>
+			<char>預</char>
+			<meaning>Entrust with; Deposit</meaning>
+			<kun>あず・ける</kun>
+			<on>ヨ</on>
+			<kun>あず・かる</kun>
+		</kanji>
+		<kanji>
+			<char>容</char>
+			<meaning>Accomodate; Contain; Manner</meaning>
+			<kun>い・れる</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>率</char>
+			<meaning>Ratio; Factor; Conduct</meaning>
+			<on>ソツ</on>
+			<on>リツ</on>
+			<kun>ひき・いる</kun>
+		</kanji>
+		<kanji>
+			<char>略</char>
+			<meaning>Approximate; Abbreviation; Brief</meaning>
+			<on>リャク</on>
+		</kanji>
+		<kanji>
+			<char>留</char>
+			<meaning>Stay put; Cease; Caretake</meaning>
+			<on>ル</on>
+			<kun>と・まる</kun>
+			<kun>とど・まる</kun>
+			<on>リュウ</on>
+			<kun>と・める</kun>
+			<kun>とど・める</kun>
+		</kanji>
+		<kanji>
+			<char>領</char>
+			<meaning>Territory; Posession</meaning>
+			<on>リョウ</on>
+		</kanji>
+	</category>
+	<category id="kanji_6">
+		<kanji>
+			<char>異</char>
+			<meaning>Strange; Different</meaning>
+			<kun>こと</kun>
+			<on>イ</on>
+			<kun>こと・なる</kun>
+		</kanji>
+		<kanji>
+			<char>遺</char>
+			<meaning>Bequest</meaning>
+			<on>ユイ</on>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>域</char>
+			<meaning>Zone</meaning>
+			<on>イキ</on>
+		</kanji>
+		<kanji>
+			<char>宇</char>
+			<meaning>Cosmos; Hall</meaning>
+			<on>ウ</on>
+		</kanji>
+		<kanji>
+			<char>映</char>
+			<meaning>Reflection; Image; Glory</meaning>
+			<kun>うつ・る</kun>
+			<kun>は・える</kun>
+			<on>エイ</on>
+			<kun>うつ・す</kun>
+			<kun>は・え</kun>
+		</kanji>
+		<kanji>
+			<char>延</char>
+			<meaning>Prolong; Stretch; Postpone; Meander</meaning>
+			<kun>の・びる</kun>
+			<kun>の・べる</kun>
+			<kun>の・べ</kun>
+			<on>エン</on>
+			<kun>の・ばす</kun>
+			<kun>の・び</kun>
+		</kanji>
+		<kanji>
+			<char>沿</char>
+			<meaning>Alongside</meaning>
+			<kun>そ・う</kun>
+			<on>エン</on>
+			<kun>ぞ・い</kun>
+		</kanji>
+		<kanji>
+			<char>我</char>
+			<meaning>Oneself</meaning>
+			<kun>われ</kun>
+			<kun>わ・が</kun>
+			<on>ガ</on>
+			<kun>わが</kun>
+		</kanji>
+		<kanji>
+			<char>灰</char>
+			<meaning>Ashes</meaning>
+			<kun>はい</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>拡</char>
+			<meaning>Enlargement; Diffusion</meaning>
+			<on>コウ</on>
+			<kun>ひろ・がる</kun>
+			<on>カク</on>
+			<kun>ひろ・げる</kun>
+			<kun>ひろ・める</kun>
+		</kanji>
+		<kanji>
+			<char>閣</char>
+			<meaning>Tower; Palace; Government cabinet</meaning>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>革</char>
+			<meaning>Leather; Pelt</meaning>
+			<on>カワ</on>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>割</char>
+			<meaning>Divide; Apportion; Discount</meaning>
+			<kun>わ・る</kun>
+			<kun>わ・れる</kun>
+			<on>カツ</on>
+			<kun>わり</kun>
+			<kun>さ・く</kun>
+		</kanji>
+		<kanji>
+			<char>株</char>
+			<meaning>Tree stump; Stock; Shares</meaning>
+			<kun>かぶ</kun>
+			<on>シュ</on>
+		</kanji>
+		<kanji>
+			<char>巻</char>
+			<meaning>Scroll; Volume of book; Encircle</meaning>
+			<on>ケン</on>
+			<kun>まき</kun>
+			<on>カン</on>
+			<kun>ま・く</kun>
+		</kanji>
+		<kanji>
+			<char>干</char>
+			<meaning>Dry; Dessicate</meaning>
+			<kun>ほ・す</kun>
+			<on>カン</on>
+			<kun>ひ・る</kun>
+		</kanji>
+		<kanji>
+			<char>看</char>
+			<meaning>Look after; Oversee</meaning>
+			<kun>み・る</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>簡</char>
+			<meaning>Concise; Simple</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>危</char>
+			<meaning>Danger</meaning>
+			<kun>あぶ・ない</kun>
+			<kun>あや・ぶむ</kun>
+			<on>キ</on>
+			<kun>あや・うい</kun>
+		</kanji>
+		<kanji>
+			<char>揮</char>
+			<meaning>Wield</meaning>
+			<kun>ふる・う</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>机</char>
+			<meaning>Desk; Table</meaning>
+			<on>キ</on>
+			<kun>つくえ</kun>
+		</kanji>
+		<kanji>
+			<char>貴</char>
+			<meaning>Esteem</meaning>
+			<kun>とうと・い</kun>
+			<kun>たっと・い</kun>
+			<on>キ</on>
+			<kun>とうと・ぶ</kun>
+			<kun>たっと・ぶ</kun>
+		</kanji>
+		<kanji>
+			<char>疑</char>
+			<meaning>Doubt; Suspicion</meaning>
+			<kun>うたが・う</kun>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>吸</char>
+			<meaning>Suck; Inhale</meaning>
+			<kun>す・う</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>供</char>
+			<meaning>Offering; Attendant</meaning>
+			<kun>そな・える</kun>
+			<kun>そな・え</kun>
+			<on>グ</on>
+			<on>キョウ</on>
+			<kun>とも</kun>
+			<on>ク</on>
+		</kanji>
+		<kanji>
+			<char>胸</char>
+			<meaning>Breast; Chest</meaning>
+			<kun>むね</kun>
+			<on>キョウ</on>
+			<kun>むな</kun>
+		</kanji>
+		<kanji>
+			<char>郷</char>
+			<meaning>Hometown</meaning>
+			<on>ゴウ</on>
+			<on>キョウ</on>
+			<kun>さと</kun>
+		</kanji>
+		<kanji>
+			<char>勤</char>
+			<meaning>Diligence; Service</meaning>
+			<on>ゴン</on>
+			<kun>つと・まる</kun>
+			<kun>つと・め</kun>
+			<on>キン</on>
+			<kun>つと・める</kun>
+			<kun>いそ・しむ</kun>
+		</kanji>
+		<kanji>
+			<char>筋</char>
+			<meaning>Muscle; Sinew; Plan</meaning>
+			<kun>すじ</kun>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>敬</char>
+			<meaning>Respect; Admire</meaning>
+			<on>キョウ</on>
+			<on>ケイ</on>
+			<kun>うやま・う</kun>
+		</kanji>
+		<kanji>
+			<char>系</char>
+			<meaning>Pedigree</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>警</char>
+			<meaning>Guard; Admonish</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>劇</char>
+			<meaning>Drama; Play</meaning>
+			<on>ゲキ</on>
+		</kanji>
+		<kanji>
+			<char>激</char>
+			<meaning>Intense</meaning>
+			<kun>はげ・しい</kun>
+			<on>ゲキ</on>
+		</kanji>
+		<kanji>
+			<char>穴</char>
+			<meaning>Hole; Cave</meaning>
+			<kun>あな</kun>
+			<on>ケツ</on>
+		</kanji>
+		<kanji>
+			<char>憲</char>
+			<meaning>Constitution; Charter; Authority</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>権</char>
+			<meaning>Authority; Rights</meaning>
+			<on>ゴン</on>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>絹</char>
+			<meaning>Silk</meaning>
+			<kun>きぬ</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>厳</char>
+			<meaning>Stern; Strict; Dignified</meaning>
+			<on>ゴン</on>
+			<kun>いか・めしい</kun>
+			<on>ゲン</on>
+			<kun>きび・しい</kun>
+		</kanji>
+		<kanji>
+			<char>源</char>
+			<meaning>Origin; Source</meaning>
+			<kun>みなもと</kun>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>呼</char>
+			<meaning>Call; Beckon</meaning>
+			<kun>よ・ぶ</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>己</char>
+			<meaning>Self</meaning>
+			<on>コ</on>
+			<kun>つちのと</kun>
+			<on>キ</on>
+			<kun>おのれ</kun>
+		</kanji>
+		<kanji>
+			<char>誤</char>
+			<meaning>Err; Mistake</meaning>
+			<on>ゴ</on>
+			<kun>あやま・る</kun>
+		</kanji>
+		<kanji>
+			<char>后</char>
+			<meaning>Empress; Queen</meaning>
+			<on>ゴ</on>
+			<on>コウ</on>
+			<kun>きさき</kun>
+		</kanji>
+		<kanji>
+			<char>孝</char>
+			<meaning>Consider; Deliber</meaning>
+			<kun>かんが・える</kun>
+			<on>コウ</on>
+			<kun>かんが・え</kun>
+		</kanji>
+		<kanji>
+			<char>皇</char>
+			<meaning>Emperor; Imperial</meaning>
+			<on>オウ</on>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>紅</char>
+			<meaning>Crimson</meaning>
+			<kun>べに</kun>
+			<on>ク</on>
+			<on>コウ</on>
+			<kun>くれない</kun>
+		</kanji>
+		<kanji>
+			<char>鋼</char>
+			<meaning>Steel</meaning>
+			<kun>はがね</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>降</char>
+			<meaning>Descend; Precipitate</meaning>
+			<kun>お・りる</kun>
+			<kun>ふ・る</kun>
+			<kun>くだ・す</kun>
+			<on>コウ</on>
+			<kun>お・ろす</kun>
+			<kun>ふ・り</kun>
+			<kun>くだ・る</kun>
+		</kanji>
+		<kanji>
+			<char>刻</char>
+			<meaning>Short period; Engrave</meaning>
+			<kun>きざ・む</kun>
+			<kun>きざ・み</kun>
+			<on>コク</on>
+			<kun>きざ</kun>
+		</kanji>
+		<kanji>
+			<char>穀</char>
+			<meaning>Cereal</meaning>
+			<kun>たけ</kun>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>骨</char>
+			<meaning>Bone</meaning>
+			<kun>ほね</kun>
+			<on>コツ</on>
+		</kanji>
+		<kanji>
+			<char>困</char>
+			<meaning>Distress; Trouble</meaning>
+			<kun>こま・る</kun>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>砂</char>
+			<meaning>Sand</meaning>
+			<kun>すな</kun>
+			<on>サ</on>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>座</char>
+			<meaning>Seat; Throne</meaning>
+			<kun>すわ・る</kun>
+			<on>ザ</on>
+		</kanji>
+		<kanji>
+			<char>済</char>
+			<meaning>Settlement; Completion</meaning>
+			<kun>す・む</kun>
+			<kun>す・ませる</kun>
+			<on>セイ</on>
+			<on>サイ</on>
+			<kun>す・ます</kun>
+			<kun>す・み</kun>
+		</kanji>
+		<kanji>
+			<char>裁</char>
+			<meaning>Judgement; Tribunal</meaning>
+			<kun>た・つ</kun>
+			<kun>さば・き</kun>
+			<on>サイ</on>
+			<kun>さば・く</kun>
+			<kun>た・ち</kun>
+		</kanji>
+		<kanji>
+			<char>策</char>
+			<meaning>Plan; Scheme; Policy</meaning>
+			<on>サク</on>
+		</kanji>
+		<kanji>
+			<char>冊</char>
+			<meaning>Volume of a book</meaning>
+			<on>サク</on>
+			<on>サツ</on>
+		</kanji>
+		<kanji>
+			<char>蚕</char>
+			<meaning>Silkworm</meaning>
+			<kun>かいこ</kun>
+			<on>サン</on>
+			<kun>こ</kun>
+		</kanji>
+		<kanji>
+			<char>姿</char>
+			<meaning>Form; Shape</meaning>
+			<kun>すがた</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>私</char>
+			<meaning>I; Personal; Private</meaning>
+			<kun>わたし</kun>
+			<on>シ</on>
+			<kun>わたくし</kun>
+		</kanji>
+		<kanji>
+			<char>至</char>
+			<meaning>Climax; Arrival</meaning>
+			<kun>いた・る</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>視</char>
+			<meaning>Inspect; View</meaning>
+			<kun>み・る</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>詞</char>
+			<meaning>Part of speech; Speech; Prayer; Words</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>誌</char>
+			<meaning>Document; Magazine; Record</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>磁</char>
+			<meaning>Magnetic; Porcelain</meaning>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>射</char>
+			<meaning>Shoot; Inject; Radiate</meaning>
+			<kun>い・る</kun>
+			<on>シャ</on>
+			<kun>さ・す</kun>
+		</kanji>
+		<kanji>
+			<char>捨</char>
+			<meaning>Discard</meaning>
+			<kun>す・てる</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>尺</char>
+			<meaning>Measure; Unit of length</meaning>
+			<on>セキ</on>
+			<kun>あた</kun>
+			<on>シャク</on>
+			<kun>さし</kun>
+			<on>サカ</on>
+		</kanji>
+		<kanji>
+			<char>若</char>
+			<meaning>Young</meaning>
+			<kun>わか・い</kun>
+			<kun>も・し</kun>
+			<on>ジャク</on>
+			<kun>わか</kun>
+		</kanji>
+		<kanji>
+			<char>樹</char>
+			<meaning>Woodland; Timber</meaning>
+			<kun>き</kun>
+			<on>ジュ</on>
+		</kanji>
+		<kanji>
+			<char>収</char>
+			<meaning>Income; Collection</meaning>
+			<kun>おさ・める</kun>
+			<on>シュウ</on>
+			<kun>おさ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>宗</char>
+			<meaning>Religion; Doctrine</meaning>
+			<on>ソウ</on>
+			<on>シュウ</on>
+			<kun>むね</kun>
+		</kanji>
+		<kanji>
+			<char>就</char>
+			<meaning>Take a seat; Put in place</meaning>
+			<on>ジュ</on>
+			<kun>つ・ける</kun>
+			<on>シュウ</on>
+			<kun>つ・く</kun>
+		</kanji>
+		<kanji>
+			<char>衆</char>
+			<meaning>The People; The Public</meaning>
+			<on>シュ</on>
+			<on>シュウ</on>
+			<on>ス</on>
+		</kanji>
+		<kanji>
+			<char>従</char>
+			<meaning>Obedience; Accordance</meaning>
+			<kun>したが・う</kun>
+			<on>ショウ</on>
+			<on>ジュウ</on>
+			<kun>したが・える</kun>
+		</kanji>
+		<kanji>
+			<char>縦</char>
+			<meaning>Height; Length</meaning>
+			<kun>たて</kun>
+			<on>ジュウ</on>
+		</kanji>
+		<kanji>
+			<char>縮</char>
+			<meaning>Contraction; Compression</meaning>
+			<kun>ちぢ・む</kun>
+			<kun>ちぢ・まる</kun>
+			<kun>ちぢ・らす</kun>
+			<on>シュク</on>
+			<kun>ちぢ・める</kun>
+			<kun>ちぢ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>熟</char>
+			<meaning>Ripe; Mature; Cooked; Mastery</meaning>
+			<kun>う・れる</kun>
+			<on>ジュク</on>
+		</kanji>
+		<kanji>
+			<char>純</char>
+			<meaning>Purity</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>処</char>
+			<meaning>Where; There; Disposal</meaning>
+			<kun>こ</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>署</char>
+			<meaning>Government office; Station; Signature</meaning>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>諸</char>
+			<meaning>Assorted</meaning>
+			<kun>もろ</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>除</char>
+			<meaning>Removal; Excision</meaning>
+			<kun>のぞ・く</kun>
+			<on>ジ</on>
+			<on>ジョ</on>
+			<kun>よ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>傷</char>
+			<meaning>Wound; Scar</meaning>
+			<kun>きず</kun>
+			<kun>いた・める</kun>
+			<on>ショウ</on>
+			<kun>いた・む</kun>
+		</kanji>
+		<kanji>
+			<char>将</char>
+			<meaning>Leader; General; Future</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>障</char>
+			<meaning>Hinder; Interfere; Harm</meaning>
+			<kun>さわ・る</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>城</char>
+			<meaning>Castle; Fortress</meaning>
+			<kun>しろ</kun>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>蒸</char>
+			<meaning>Steam; Fumigate</meaning>
+			<on>セイ</on>
+			<kun>む・れる</kun>
+			<kun>ふ・ける</kun>
+			<on>ジョウ</on>
+			<kun>む・す</kun>
+			<kun>ふ・かす</kun>
+			<kun>む・らす</kun>
+		</kanji>
+		<kanji>
+			<char>針</char>
+			<meaning>Needle; Rod; Hook</meaning>
+			<kun>はり</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>仁</char>
+			<meaning>Benevolence; Chivalry</meaning>
+			<on>ニ</on>
+			<on>ジン</on>
+			<on>ニン</on>
+		</kanji>
+		<kanji>
+			<char>垂</char>
+			<meaning>Droop</meaning>
+			<kun>た・れる</kun>
+			<kun>た・れ</kun>
+			<on>スイ</on>
+			<kun>た・らす</kun>
+		</kanji>
+		<kanji>
+			<char>推</char>
+			<meaning>Conjecture; Revision</meaning>
+			<kun>お・す</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>寸</char>
+			<meaning>Measurement; Unit of length</meaning>
+			<on>スン</on>
+		</kanji>
+		<kanji>
+			<char>盛</char>
+			<meaning>Prosper; Serve up</meaning>
+			<on>ジョウ</on>
+			<kun>さか・る</kun>
+			<kun>さか・ん</kun>
+			<on>セイ</on>
+			<kun>も・る</kun>
+			<kun>さか・り</kun>
+		</kanji>
+		<kanji>
+			<char>聖</char>
+			<meaning>Holy; Sage</meaning>
+			<kun>ひじり</kun>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>誠</char>
+			<meaning>Earnest; Faithful</meaning>
+			<kun>まこと</kun>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>宣</char>
+			<meaning>Decree; Declaration</meaning>
+			<kun>のたま・う</kun>
+			<on>ゼン</on>
+			<on>セン</on>
+			<kun>のたまわ・く</kun>
+		</kanji>
+		<kanji>
+			<char>専</char>
+			<meaning>Specialised; Monopoly</meaning>
+			<kun>もっぱ・ら</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>泉</char>
+			<meaning>Spring; Well</meaning>
+			<kun>いずみ</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>洗</char>
+			<meaning>Wash; Cleanse</meaning>
+			<kun>あら・う</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>染</char>
+			<meaning>Dye; Stain; Contaminate</meaning>
+			<kun>そ・める</kun>
+			<kun>し・みる</kun>
+			<on>セン</on>
+			<kun>そ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>善</char>
+			<meaning>Virtue; Good</meaning>
+			<kun>よ・い</kun>
+			<on>ゼン</on>
+			<kun>い・い</kun>
+		</kanji>
+		<kanji>
+			<char>創</char>
+			<meaning>Establishment; Incision; Wound</meaning>
+			<kun>きず</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>奏</char>
+			<meaning>Play music</meaning>
+			<kun>かな・でる</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>層</char>
+			<meaning>Class; Stratum</meaning>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>操</char>
+			<meaning>Manipulation; Discipline</meaning>
+			<kun>みさお</kun>
+			<kun>あやつ・り</kun>
+			<on>ソウ</on>
+			<kun>あやつ・る</kun>
+		</kanji>
+		<kanji>
+			<char>窓</char>
+			<meaning>Window</meaning>
+			<kun>まど</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>装</char>
+			<meaning>Garment; Packaging</meaning>
+			<on>ショウ</on>
+			<kun>よそお・い</kun>
+			<on>ソウ</on>
+			<kun>よそお・う</kun>
+		</kanji>
+		<kanji>
+			<char>臓</char>
+			<meaning>Organs; Entrails</meaning>
+			<on>ゾウ</on>
+		</kanji>
+		<kanji>
+			<char>蔵</char>
+			<meaning>Posession; Storage</meaning>
+			<kun>くら</kun>
+			<on>ゾウ</on>
+		</kanji>
+		<kanji>
+			<char>存</char>
+			<meaning>Existence; Awareness</meaning>
+			<on>ゾン</on>
+			<on>ソン</on>
+			<kun>ぞん・じる</kun>
+		</kanji>
+		<kanji>
+			<char>尊</char>
+			<meaning>Noble; Revered</meaning>
+			<kun>たっと・い</kun>
+			<kun>たっと・ぶ</kun>
+			<kun>みこと</kun>
+			<on>ソン</on>
+			<kun>とうと・い</kun>
+			<kun>とうと・ぶ</kun>
+		</kanji>
+		<kanji>
+			<char>宅</char>
+			<meaning>House; You</meaning>
+			<on>タク</on>
+		</kanji>
+		<kanji>
+			<char>担</char>
+			<meaning>Support; Participate</meaning>
+			<kun>かつ・ぐ</kun>
+			<on>タン</on>
+			<kun>にな・う</kun>
+		</kanji>
+		<kanji>
+			<char>探</char>
+			<meaning>Inquire; Search for</meaning>
+			<kun>さが・す</kun>
+			<on>タン</on>
+			<kun>さぐ・る</kun>
+		</kanji>
+		<kanji>
+			<char>誕</char>
+			<meaning>Birth; Nativity</meaning>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>暖</char>
+			<meaning>Warmth</meaning>
+			<kun>あたたか・い</kun>
+			<kun>あたたか・まる</kun>
+			<on>ダン</on>
+			<kun>あたたか・める</kun>
+		</kanji>
+		<kanji>
+			<char>段</char>
+			<meaning>Flight of stairs; Tier; Terrace</meaning>
+			<on>ダン</on>
+		</kanji>
+		<kanji>
+			<char>値</char>
+			<meaning>Value; Worth; Price</meaning>
+			<kun>あたい</kun>
+			<on>チ</on>
+			<kun>ね</kun>
+		</kanji>
+		<kanji>
+			<char>宙</char>
+			<meaning>Space; Cosmos</meaning>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>忠</char>
+			<meaning>Loyalty; Devotion</meaning>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>著</char>
+			<meaning>Authorship</meaning>
+			<kun>いちじる・しい</kun>
+			<on>チャク</on>
+			<kun>あらわ・す</kun>
+			<on>チョ</on>
+		</kanji>
+		<kanji>
+			<char>庁</char>
+			<meaning>Authorities; Government office; Agency</meaning>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>潮</char>
+			<meaning>Tide; Salt water</meaning>
+			<kun>しお</kun>
+			<on>チョウ</on>
+			<kun>うしお</kun>
+		</kanji>
+		<kanji>
+			<char>頂</char>
+			<meaning>Receive; Summit; Zenith</meaning>
+			<kun>いただ・く</kun>
+			<kun>いただ・き</kun>
+			<on>チョウ</on>
+			<kun>いただき</kun>
+		</kanji>
+		<kanji>
+			<char>賃</char>
+			<meaning>Rent; Fare; Wages</meaning>
+			<on>チン</on>
+		</kanji>
+		<kanji>
+			<char>痛</char>
+			<meaning>Hurt; Pain</meaning>
+			<kun>いた・い</kun>
+			<kun>いた・める</kun>
+			<on>ツウ</on>
+			<kun>いた・む</kun>
+			<kun>いた・ましい</kun>
+		</kanji>
+		<kanji>
+			<char>展</char>
+			<meaning>Exhibition; Expansion</meaning>
+			<on>テン</on>
+		</kanji>
+		<kanji>
+			<char>党</char>
+			<meaning>Fellow; Faction; Political party</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>糖</char>
+			<meaning>Sugar</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>討</char>
+			<meaning>Combat; Arrest; Attack</meaning>
+			<kun>う・つ</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>届</char>
+			<meaning>Register; Report; Notify</meaning>
+			<kun>とど・く</kun>
+			<on>カイ</on>
+			<kun>とど・ける</kun>
+		</kanji>
+		<kanji>
+			<char>難</char>
+			<meaning>Hazard; Difficulty</meaning>
+			<kun>かた・い</kun>
+			<kun>にく・い</kun>
+			<on>ナン</on>
+			<kun>むずかし・い</kun>
+		</kanji>
+		<kanji>
+			<char>乳</char>
+			<meaning>Milk; Breasts</meaning>
+			<kun>ちち</kun>
+			<on>ニュウ</on>
+			<kun>ち</kun>
+		</kanji>
+		<kanji>
+			<char>認</char>
+			<meaning>Affirm; Confirm; Approve</meaning>
+			<kun>みと・める</kun>
+			<on>ニン</on>
+			<kun>したた・める</kun>
+		</kanji>
+		<kanji>
+			<char>納</char>
+			<meaning>Supply; Settlement</meaning>
+			<kun>おさ・める</kun>
+			<on>トウ</on>
+			<on>ノウ</on>
+			<kun>おさ・まる</kun>
+			<on>ナっ</on>
+		</kanji>
+		<kanji>
+			<char>脳</char>
+			<meaning>Brain</meaning>
+			<on>ノウ</on>
+		</kanji>
+		<kanji>
+			<char>派</char>
+			<meaning>Pulse; Vein</meaning>
+			<on>ハ</on>
+		</kanji>
+		<kanji>
+			<char>俳</char>
+			<meaning>Haiku</meaning>
+			<on>ハイ</on>
+		</kanji>
+		<kanji>
+			<char>拝</char>
+			<meaning>Worship; Supplicate</meaning>
+			<kun>おが・む</kun>
+			<on>ハイ</on>
+			<kun>おろが・む</kun>
+		</kanji>
+		<kanji>
+			<char>背</char>
+			<meaning>Stature; Back</meaning>
+			<kun>せい</kun>
+			<kun>そむ・く</kun>
+			<on>ハイ</on>
+			<kun>せ</kun>
+			<kun>そむ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>肺</char>
+			<meaning>Lungs</meaning>
+			<on>ハイ</on>
+		</kanji>
+		<kanji>
+			<char>班</char>
+			<meaning>Group; Squad</meaning>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>晩</char>
+			<meaning>Evening; Night; Late time</meaning>
+			<on>バン</on>
+		</kanji>
+		<kanji>
+			<char>否</char>
+			<meaning>No; Disapprove; Vote against</meaning>
+			<kun>いや</kun>
+			<kun>いや・む</kun>
+			<on>ヒ</on>
+			<kun>いな・む</kun>
+			<kun>いな</kun>
+		</kanji>
+		<kanji>
+			<char>批</char>
+			<meaning>Critique</meaning>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>秘</char>
+			<meaning>Secret; Secluded</meaning>
+			<kun>ひ・める</kun>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>腹</char>
+			<meaning>Stomach; Gut</meaning>
+			<kun>はら</kun>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>奮</char>
+			<meaning>Excitement; Impetuousness</meaning>
+			<kun>ふる・う</kun>
+			<on>フン</on>
+		</kanji>
+		<kanji>
+			<char>並</char>
+			<meaning>Row; Line up</meaning>
+			<kun>なら・びに</kun>
+			<kun>なら・ぶ</kun>
+			<kun>な・み</kun>
+			<on>ヘイ</on>
+			<kun>なら・べる</kun>
+			<kun>なみ</kun>
+		</kanji>
+		<kanji>
+			<char>閉</char>
+			<meaning>Shut; Close</meaning>
+			<kun>し・める</kun>
+			<kun>と・じる</kun>
+			<on>ヘイ</on>
+			<kun>し・まる</kun>
+			<kun>と・ざる</kun>
+		</kanji>
+		<kanji>
+			<char>陛</char>
+			<meaning>Your Highness; Your Majesty</meaning>
+			<on>ヘイ</on>
+		</kanji>
+		<kanji>
+			<char>片</char>
+			<meaning>One-sided; Fragment; Segment</meaning>
+			<kun>かた</kun>
+			<on>ヘン</on>
+		</kanji>
+		<kanji>
+			<char>補</char>
+			<meaning>Candidate; Compensate</meaning>
+			<kun>おぎな・う</kun>
+			<on>ホ</on>
+		</kanji>
+		<kanji>
+			<char>暮</char>
+			<meaning>Lifestyle; Darken; Dusk</meaning>
+			<kun>く・れる</kun>
+			<on>ボ</on>
+			<kun>く・らす</kun>
+		</kanji>
+		<kanji>
+			<char>宝</char>
+			<meaning>Treasure</meaning>
+			<kun>たから</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>訪</char>
+			<meaning>Visit; Call upon</meaning>
+			<kun>たず・ねる</kun>
+			<on>ホウ</on>
+			<kun>おとず・れる</kun>
+		</kanji>
+		<kanji>
+			<char>亡</char>
+			<meaning>Decease; Perish; Ruined</meaning>
+			<on>モウ</on>
+			<on>ボウ</on>
+			<kun>な・い</kun>
+		</kanji>
+		<kanji>
+			<char>忘</char>
+			<meaning>Forget</meaning>
+			<kun>わす・れる</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>棒</char>
+			<meaning>Rod; Baton; Partner</meaning>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>枚</char>
+			<meaning>Flat sheet</meaning>
+			<on>マイ</on>
+		</kanji>
+		<kanji>
+			<char>幕</char>
+			<meaning>Curtain; Banner</meaning>
+			<on>バク</on>
+			<on>マク</on>
+		</kanji>
+		<kanji>
+			<char>密</char>
+			<meaning>Secret; Confidential</meaning>
+			<on>ミツ</on>
+		</kanji>
+		<kanji>
+			<char>盟</char>
+			<meaning>Alliance; Federation</meaning>
+			<on>メイ</on>
+		</kanji>
+		<kanji>
+			<char>模</char>
+			<meaning>Scale; Imitation; Signs</meaning>
+			<on>ボ</on>
+			<on>モ</on>
+		</kanji>
+		<kanji>
+			<char>訳</char>
+			<meaning>Translation; Explanation</meaning>
+			<kun>わけ</kun>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>優</char>
+			<meaning>Gentle; Actor; Excel</meaning>
+			<kun>やさ</kun>
+			<kun>まさ・る</kun>
+			<on>ウ</on>
+			<on>ユウ</on>
+			<kun>やさ・しい</kun>
+			<kun>すぐ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>郵</char>
+			<meaning>Postal</meaning>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>幼</char>
+			<meaning>Childhood; Infancy</meaning>
+			<kun>おさな・い</kun>
+			<on>ヨウ</on>
+			<kun>おさな</kun>
+		</kanji>
+		<kanji>
+			<char>欲</char>
+			<meaning>Desire; Want</meaning>
+			<kun>ほ・しい</kun>
+			<on>ヨク</on>
+			<kun>ほ・する</kun>
+		</kanji>
+		<kanji>
+			<char>翌</char>
+			<meaning>The following</meaning>
+			<on>ヨク</on>
+		</kanji>
+		<kanji>
+			<char>乱</char>
+			<meaning>Discorder; Confusion</meaning>
+			<kun>みだ・る</kun>
+			<kun>みだ・れる</kun>
+			<on>ラン</on>
+			<kun>みだ・す</kun>
+		</kanji>
+		<kanji>
+			<char>卵</char>
+			<meaning>Egg</meaning>
+			<kun>たまご</kun>
+			<on>ラン</on>
+		</kanji>
+		<kanji>
+			<char>覧</char>
+			<meaning>Inspection; Exhibition</meaning>
+			<kun>み・る</kun>
+			<on>ラン</on>
+		</kanji>
+		<kanji>
+			<char>裏</char>
+			<meaning>Reverse; Underside</meaning>
+			<kun>うら</kun>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>律</char>
+			<meaning>Principle; Law</meaning>
+			<on>リチ</on>
+			<on>リツ</on>
+		</kanji>
+		<kanji>
+			<char>臨</char>
+			<meaning>Advent; Deal with; Opportune</meaning>
+			<kun>のぞ・む</kun>
+			<on>リン</on>
+		</kanji>
+		<kanji>
+			<char>朗</char>
+			<meaning>Clear; Serene</meaning>
+			<kun>あき・らか</kun>
+			<on>ロウ</on>
+			<kun>ほが・らか</kun>
+		</kanji>
+		<kanji>
+			<char>論</char>
+			<meaning>Debate</meaning>
+			<on>ロン</on>
+		</kanji>
+	</category>
+	<category id="kanji_7">
+		<kanji>
+			<char>亜</char>
+			<meaning>Sub-; Asia</meaning>
+			<on>ア</on>
+		</kanji>
+		<kanji>
+			<char>哀</char>
+			<meaning>Pity; Sympathise with; Sorrow</meaning>
+			<kun>かな・しみ</kun>
+			<kun>あわ・れ</kun>
+			<kun>あわ・れみ</kun>
+			<kun>かな・しい</kun>
+			<kun>かな・しむ</kun>
+			<on>アイ</on>
+			<kun>あわ・れむ</kun>
+		</kanji>
+		<kanji>
+			<char>握</char>
+			<meaning>Grasp; Grip; Handle</meaning>
+			<kun>にぎ・り</kun>
+			<kun>にぎ・る</kun>
+			<on>アク</on>
+		</kanji>
+		<kanji>
+			<char>扱</char>
+			<meaning>Deal with; Handle; Thresh</meaning>
+			<kun>あつか・い</kun>
+			<kun>あつかい</kun>
+			<kun>あつか・う</kun>
+			<kun>しご・く</kun>
+			<kun>こ・く</kun>
+		</kanji>
+		<kanji>
+			<char>依</char>
+			<meaning>Depend on; Due to; According to</meaning>
+			<on>エ</on>
+			<on>イ</on>
+			<kun>よ・る</kun>
+		</kanji>
+		<kanji>
+			<char>偉</char>
+			<meaning>Be conceited; Great; Magnificent</meaning>
+			<kun>えら・い</kun>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>威</char>
+			<meaning>Threaten; Influence; Majesty</meaning>
+			<kun>おど・す</kun>
+			<on>イ</on>
+			<kun>おど・し</kun>
+		</kanji>
+		<kanji>
+			<char>尉</char>
+			<meaning>Jailer; Military officer</meaning>
+			<on>ジョウ</on>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>慰</char>
+			<meaning>Console; Comfort; Divert</meaning>
+			<kun>なぐさ・む</kun>
+			<kun>なぐさ・め</kun>
+			<on>イ</on>
+			<kun>なぐさ・み</kun>
+			<kun>なぐさ・める</kun>
+		</kanji>
+		<kanji>
+			<char>為</char>
+			<meaning>Do; Make; Result of</meaning>
+			<on>イ</on>
+			<kun>な・す</kun>
+			<kun>す・る</kun>
+			<kun>ため</kun>
+			<kun>な・さる</kun>
+			<kun>し</kun>
+			<kun>な・る</kun>
+		</kanji>
+		<kanji>
+			<char>維</char>
+			<meaning>Fibre; Textile; Maintenance</meaning>
+			<on>イ</on>
+		</kanji>
+		<kanji>
+			<char>緯</char>
+			<meaning>Latitude; Woof of thread</meaning>
+			<kun>ぬき</kun>
+			<on>イ</on>
+			<kun>よこ</kun>
+		</kanji>
+		<kanji>
+			<char>違</char>
+			<meaning>Differ from; Change; Contrary to</meaning>
+			<kun>ちが・う</kun>
+			<kun>ちが・える</kun>
+			<kun>たが・える</kun>
+			<on>イ</on>
+			<kun>ちが・い</kun>
+			<kun>たが・う</kun>
+		</kanji>
+		<kanji>
+			<char>井</char>
+			<meaning>Well; Sluice</meaning>
+			<kun>い</kun>
+			<on>ジョウ</on>
+			<on>セイ</on>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>壱</char>
+			<meaning>One</meaning>
+			<on>イチ</on>
+		</kanji>
+		<kanji>
+			<char>逸</char>
+			<meaning>Deviate; Avert; Idle</meaning>
+			<on>イっ</on>
+			<kun>はや・る</kun>
+			<kun>はぐ・れる</kun>
+			<on>イツ</on>
+			<kun>そ・らす</kun>
+			<on>イチ</on>
+			<kun>そ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>稲</char>
+			<meaning>Rice plant</meaning>
+			<kun>いな</kun>
+			<on>トウ</on>
+			<kun>いね</kun>
+		</kanji>
+		<kanji>
+			<char>芋</char>
+			<meaning>Potato</meaning>
+			<kun>いも</kun>
+			<on>ウ</on>
+		</kanji>
+		<kanji>
+			<char>姻</char>
+			<meaning>Marriage</meaning>
+			<on>イン</on>
+		</kanji>
+		<kanji>
+			<char>陰</char>
+			<meaning>Yin; Shadow; Genitals</meaning>
+			<kun>かげ</kun>
+			<kun>かげ・り</kun>
+			<on>イン</on>
+			<kun>かげ・る</kun>
+		</kanji>
+		<kanji>
+			<char>隠</char>
+			<meaning>Hide; Conceal; Seclusion</meaning>
+			<kun>かく・れる</kun>
+			<kun>かく・し</kun>
+			<on>オン</on>
+			<kun>かく・す</kun>
+			<on>イン</on>
+			<kun>かく・れ</kun>
+		</kanji>
+		<kanji>
+			<char>韻</char>
+			<meaning>Rhyme; Verse; Tone</meaning>
+			<on>イン</on>
+		</kanji>
+		<kanji>
+			<char>渦</char>
+			<meaning>Whirlpool; Vortex; Spiral</meaning>
+			<on>カ</on>
+			<kun>うず</kun>
+		</kanji>
+		<kanji>
+			<char>浦</char>
+			<meaning>Inlet; Coast; Shore</meaning>
+			<on>ホ</on>
+			<kun>うら</kun>
+		</kanji>
+		<kanji>
+			<char>影</char>
+			<meaning>Shadow; Silhouette; Image</meaning>
+			<kun>かげ</kun>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>詠</char>
+			<meaning>Recite; Compose; Poem</meaning>
+			<kun>よ・む</kun>
+			<on>エイ</on>
+			<kun>なが・む</kun>
+		</kanji>
+		<kanji>
+			<char>鋭</char>
+			<meaning>Sharp; Pointed</meaning>
+			<kun>するど・い</kun>
+			<on>エイ</on>
+		</kanji>
+		<kanji>
+			<char>疫</char>
+			<meaning>Epidemic</meaning>
+			<on>ヤク</on>
+			<on>エキ</on>
+		</kanji>
+		<kanji>
+			<char>悦</char>
+			<meaning>Ecstasy; Rapture; Joy</meaning>
+			<kun>よろこ・ぶ</kun>
+			<kun>よろこ・び</kun>
+			<on>エツ</on>
+			<kun>よろこ・ばす</kun>
+		</kanji>
+		<kanji>
+			<char>謁</char>
+			<meaning>Hold audience</meaning>
+			<kun>え・する</kun>
+			<on>エツ</on>
+			<on>エっ</on>
+		</kanji>
+		<kanji>
+			<char>越</char>
+			<meaning>Surpass; Move residence; Vietnam</meaning>
+			<kun>こ・える</kun>
+			<kun>こ・す</kun>
+			<on>エツ</on>
+			<kun>ご・し</kun>
+		</kanji>
+		<kanji>
+			<char>閲</char>
+			<meaning>Inspection; Examination; Review</meaning>
+			<on>エっ</on>
+			<on>エツ</on>
+			<kun>けみ・する</kun>
+		</kanji>
+		<kanji>
+			<char>宴</char>
+			<meaning>Banquet; Feast; Party</meaning>
+			<on>エン</on>
+			<kun>うたげ</kun>
+		</kanji>
+		<kanji>
+			<char>援</char>
+			<meaning>Support; Reinforcement</meaning>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>炎</char>
+			<meaning>Blaze; Flame</meaning>
+			<kun>ほのお</kun>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>煙</char>
+			<meaning>Smoke</meaning>
+			<kun>けむり</kun>
+			<kun>けむ・たい</kun>
+			<on>エン</on>
+			<kun>けむ・い</kun>
+			<kun>けむ・る</kun>
+		</kanji>
+		<kanji>
+			<char>猿</char>
+			<meaning>Monkey</meaning>
+			<kun>さる</kun>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>縁</char>
+			<meaning>Karmic connection; Fringe; Means</meaning>
+			<kun>ふち</kun>
+			<kun>ゆかり</kun>
+			<kun>えにし</kun>
+			<on>ネン</on>
+			<kun>へり</kun>
+			<on>エン</on>
+			<kun>えに</kun>
+			<kun>よすが</kun>
+		</kanji>
+		<kanji>
+			<char>鉛</char>
+			<meaning>Lead metal</meaning>
+			<kun>なまり</kun>
+			<on>エン</on>
+		</kanji>
+		<kanji>
+			<char>汚</char>
+			<meaning>Disgrace; Dishonour; Become dirty</meaning>
+			<kun>きたな・い</kun>
+			<kun>けが・らわしい</kun>
+			<kun>けが・れる</kun>
+			<kun>よご・れる</kun>
+			<kun>けが・れ</kun>
+			<on>オ</on>
+			<kun>よご・す</kun>
+			<kun>よご・れ</kun>
+			<kun>けが・す</kun>
+		</kanji>
+		<kanji>
+			<char>凹</char>
+			<meaning>Indent; Hollow; Concave</meaning>
+			<kun>ぼこ</kun>
+			<kun>へこ・ませる</kun>
+			<kun>くぼ・める</kun>
+			<kun>くぼ</kun>
+			<kun>へこ・む</kun>
+			<on>オウ</on>
+			<kun>へこ・ます</kun>
+			<kun>へこ・み</kun>
+			<kun>くぼ・まる</kun>
+		</kanji>
+		<kanji>
+			<char>奥</char>
+			<meaning>Extend back; Core; Interior</meaning>
+			<on>オク</on>
+			<on>オウ</on>
+			<kun>おく・まる</kun>
+		</kanji>
+		<kanji>
+			<char>押</char>
+			<meaning>Push; Press down; Forceful</meaning>
+			<kun>おさ・える</kun>
+			<kun>お・す</kun>
+			<kun>おし</kun>
+			<on>オウ</on>
+			<kun>おさ・え</kun>
+			<kun>お・し</kun>
+		</kanji>
+		<kanji>
+			<char>欧</char>
+			<meaning>Europe</meaning>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>殴</char>
+			<meaning>Hit; Strike</meaning>
+			<kun>なぐ・る</kun>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>翁</char>
+			<meaning>Old man; Venerable</meaning>
+			<kun>おきな</kun>
+			<on>オウ</on>
+		</kanji>
+		<kanji>
+			<char>沖</char>
+			<meaning>Climb high; Open sea</meaning>
+			<on>チュウ</on>
+			<kun>おき</kun>
+			<kun>ちゅう・する</kun>
+		</kanji>
+		<kanji>
+			<char>憶</char>
+			<meaning>Remember; Memory</meaning>
+			<kun>おぼ・える</kun>
+			<on>オク</on>
+		</kanji>
+		<kanji>
+			<char>乙</char>
+			<meaning>Quaint; Maiden</meaning>
+			<kun>きのと</kun>
+			<kun>おと</kun>
+			<on>オツ</on>
+			<on>イツ</on>
+		</kanji>
+		<kanji>
+			<char>卸</char>
+			<meaning>Wholesale</meaning>
+			<kun>おろ・す</kun>
+			<kun>おろし</kun>
+		</kanji>
+		<kanji>
+			<char>穏</char>
+			<meaning>Calm; Peaceful; Tranquility</meaning>
+			<kun>おだ・やか</kun>
+			<on>オン</on>
+		</kanji>
+		<kanji>
+			<char>佳</char>
+			<meaning>Excellent; Scenic; Beautiful</meaning>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>嫁</char>
+			<meaning>Marry; Bride</meaning>
+			<on>カ</on>
+			<kun>よめ</kun>
+			<kun>とつ・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>寡</char>
+			<meaning>Widow; Few; Humble</meaning>
+			<kun>やもめ</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>暇</char>
+			<meaning>Free time; Leisure</meaning>
+			<on>カ</on>
+			<kun>いとま</kun>
+			<kun>ひま</kun>
+		</kanji>
+		<kanji>
+			<char>架</char>
+			<meaning>Hang something; Shelf; Stand</meaning>
+			<kun>か・かる</kun>
+			<on>カ</on>
+			<kun>か・ける</kun>
+		</kanji>
+		<kanji>
+			<char>禍</char>
+			<meaning>Catastrophe; Devastation; Evil</meaning>
+			<kun>まが</kun>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>稼</char>
+			<meaning>Earn money; Work; Make a living</meaning>
+			<kun>かせ・ぐ</kun>
+			<on>カ</on>
+			<kun>かせ・ぎ</kun>
+			<kun>かせ・げる</kun>
+		</kanji>
+		<kanji>
+			<char>箇</char>
+			<meaning>Counter for Things</meaning>
+			<on>カ</on>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>華</char>
+			<meaning>Become brilliant; Flower; Petal</meaning>
+			<on>ゲ</on>
+			<kun>やな・やか</kun>
+			<on>カ</on>
+			<kun>はな</kun>
+			<kun>はな・やぐ</kun>
+		</kanji>
+		<kanji>
+			<char>菓</char>
+			<meaning>Confectionery; Cake</meaning>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>蚊</char>
+			<meaning>Mosquito</meaning>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>雅</char>
+			<meaning>Appear refined; Graceful; Elegant</meaning>
+			<kun>みや・ぶ</kun>
+			<kun>みや・びる</kun>
+			<on>ガ</on>
+			<kun>みや・びやか</kun>
+		</kanji>
+		<kanji>
+			<char>餓</char>
+			<meaning>Hunger; Starve; Thirst</meaning>
+			<kun>う・える</kun>
+			<on>ガ</on>
+		</kanji>
+		<kanji>
+			<char>介</char>
+			<meaning>Shellfish; By means of; Intervention</meaning>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>塊</char>
+			<meaning>Lump; Mass; Clod</meaning>
+			<kun>かたまり</kun>
+			<kun>ほど</kun>
+			<kun>まろかせ</kun>
+			<on>カイ</on>
+			<kun>くれ</kun>
+			<kun>まろかし</kun>
+		</kanji>
+		<kanji>
+			<char>壊</char>
+			<meaning>Destroy; Collapse; Break</meaning>
+			<kun>こわ・す</kun>
+			<on>エ</on>
+			<on>カイ</on>
+			<kun>こわ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>怪</char>
+			<meaning>Suspect something; Suspicious; Mysterious</meaning>
+			<kun>あや・しい</kun>
+			<kun>あや・しむ</kun>
+			<on>カイ</on>
+			<kun>あや・しげ</kun>
+			<on>ケ</on>
+		</kanji>
+		<kanji>
+			<char>悔</char>
+			<meaning>Mourn; Regret; Vexatious</meaning>
+			<kun>く・いる</kun>
+			<kun>くや・しい</kun>
+			<kun>くや・む</kun>
+			<on>カイ</on>
+			<kun>く・い</kun>
+			<kun>くや・み</kun>
+		</kanji>
+		<kanji>
+			<char>懐</char>
+			<meaning>Long for; Win over; Bosom</meaning>
+			<kun>ふところ</kun>
+			<kun>なつ・く</kun>
+			<on>カイ</on>
+			<kun>なつ・かしい</kun>
+			<kun>なつ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>戒</char>
+			<meaning>Admonish; Warning; Commandment</meaning>
+			<kun>いまし・める</kun>
+			<on>カイ</on>
+			<kun>いまし・め</kun>
+		</kanji>
+		<kanji>
+			<char>拐</char>
+			<meaning>Abduct; Kidnap; Abscond</meaning>
+			<kun>さら・う</kun>
+			<on>カイ</on>
+			<kun>かどわ・かす</kun>
+		</kanji>
+		<kanji>
+			<char>皆</char>
+			<meaning>Everyone; Complete</meaning>
+			<kun>みな</kun>
+			<kun>みんあ</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>劾</char>
+			<meaning>Impeach; Censure; Investigate</meaning>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>慨</char>
+			<meaning>Lamentation; Regret; Resentment</meaning>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>概</char>
+			<meaning>In general; Summary; Overview</meaning>
+			<kun>おおむ・ね</kun>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>涯</char>
+			<meaning>Horizon; Outer limits</meaning>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>該</char>
+			<meaning>Corresponding to; The aforementioned</meaning>
+			<on>ガイ</on>
+		</kanji>
+		<kanji>
+			<char>垣</char>
+			<meaning>Fence; Hedge; Wall</meaning>
+			<kun>がき</kun>
+			<kun>かき</kun>
+		</kanji>
+		<kanji>
+			<char>嚇</char>
+			<meaning>Threat; Intimidation</meaning>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>核</char>
+			<meaning>Nucleus; Kernel; Core</meaning>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>殻</char>
+			<meaning>Shell; Carapace; Chaff</meaning>
+			<kun>から</kun>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>獲</char>
+			<meaning>Catch; Get; Gain</meaning>
+			<kun>え・る</kun>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>穫</char>
+			<meaning>Crop; Harvest</meaning>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>較</char>
+			<meaning>Compare; Calibrate</meaning>
+			<kun>くら・べる</kun>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>郭</char>
+			<meaning>Enclosure; Wall; Fortification</meaning>
+			<kun>くるわ</kun>
+			<on>カク</on>
+		</kanji>
+		<kanji>
+			<char>隔</char>
+			<meaning>Stand distant from; Estrange; Isolated</meaning>
+			<kun>へだ・たる</kun>
+			<kun>へだ・たり</kun>
+			<on>カク</on>
+			<kun>へだ・てる</kun>
+			<kun>へだ・て</kun>
+		</kanji>
+		<kanji>
+			<char>岳</char>
+			<meaning>Mountain peak</meaning>
+			<kun>たけ</kun>
+			<on>ガク</on>
+		</kanji>
+		<kanji>
+			<char>掛</char>
+			<meaning>Perform an action; Hang an object; Spend money or time</meaning>
+			<kun>か・ける</kun>
+			<kun>か・かり</kun>
+			<kun>か・く</kun>
+			<on>カク</on>
+			<kun>か・かる</kun>
+			<kun>か・け</kun>
+		</kanji>
+		<kanji>
+			<char>潟</char>
+			<meaning>Lagoon</meaning>
+			<kun>かた</kun>
+		</kanji>
+		<kanji>
+			<char>喝</char>
+			<meaning>Proclamation; Loud voice</meaning>
+			<on>カっ</on>
+			<on>カツ</on>
+		</kanji>
+		<kanji>
+			<char>括</char>
+			<meaning>Bind together; Synthesise; Bundle up</meaning>
+			<kun>くく・る</kun>
+			<on>カツ</on>
+		</kanji>
+		<kanji>
+			<char>渇</char>
+			<meaning>Dry up; Thirst</meaning>
+			<kun>かわ・く</kun>
+			<on>カっ</on>
+			<on>カツ</on>
+			<kun>かわ・き</kun>
+		</kanji>
+		<kanji>
+			<char>滑</char>
+			<meaning>Slide; Slip; Smooth</meaning>
+			<on>コツ</on>
+			<kun>すべ・らす</kun>
+			<on>コっ</on>
+			<kun>すべ・り</kun>
+			<on>カツ</on>
+			<kun>なめ・らか</kun>
+			<on>カっ</on>
+			<kun>すべ・る</kun>
+		</kanji>
+		<kanji>
+			<char>褐</char>
+			<meaning>Brown</meaning>
+			<on>カっ</on>
+			<on>カツ</on>
+		</kanji>
+		<kanji>
+			<char>轄</char>
+			<meaning>Jurisdiction; Supervision</meaning>
+			<on>カツ</on>
+		</kanji>
+		<kanji>
+			<char>且</char>
+			<meaning>Besides; Moreover; Furthermore</meaning>
+			<kun>か・つ</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>刈</char>
+			<meaning>Reap; Mow; Cut</meaning>
+			<kun>か・る</kun>
+			<on>カイ</on>
+		</kanji>
+		<kanji>
+			<char>乾</char>
+			<meaning>Dry out; Dessicate; Heaven</meaning>
+			<on>ケン</on>
+			<kun>かわ・かす</kun>
+			<kun>から</kun>
+			<kun>から・びる</kun>
+			<kun>ひ・る</kun>
+			<kun>ほ・す</kun>
+			<on>カン</on>
+			<kun>ほし</kun>
+			<kun>いぬい</kun>
+			<kun>か・せる</kun>
+			<kun>かわ・く</kun>
+		</kanji>
+		<kanji>
+			<char>冠</char>
+			<meaning>Crown; Laurels; Cap</meaning>
+			<kun>かんむり</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>勘</char>
+			<meaning>Intuition</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>勧</char>
+			<meaning>Recommend; Advise; Solicit</meaning>
+			<kun>すす・める</kun>
+			<kun>すす・む</kun>
+			<on>カン</on>
+			<kun>すす・め</kun>
+		</kanji>
+		<kanji>
+			<char>喚</char>
+			<meaning>Scream; Shout; Summons</meaning>
+			<kun>わめ・く</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>堪</char>
+			<meaning>Endure; Withstand; Bear</meaning>
+			<kun>こた・える</kun>
+			<on>カン</on>
+			<kun>たま・る</kun>
+			<kun>た・える</kun>
+			<kun>こら・える</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>寛</char>
+			<meaning>Relax; Loosen clothes; Tolerance</meaning>
+			<kun>くつろ・ぐ</kun>
+			<kun>くつろ・ぎ</kun>
+			<kun>ひろ・い</kun>
+			<kun>くつろ・げる</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>患</char>
+			<meaning>Fall ill; Ailment; Illness</meaning>
+			<kun>わずら・う</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>憾</char>
+			<meaning>Regrettable</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>換</char>
+			<meaning>Exchange; Convert; Substitute</meaning>
+			<kun>か・える</kun>
+			<kun>か・わる</kun>
+			<on>カン</on>
+			<kun>か・え</kun>
+			<kun>か・わり</kun>
+		</kanji>
+		<kanji>
+			<char>敢</char>
+			<meaning>Boldly; Dare to do</meaning>
+			<kun>あ・えて</kun>
+			<kun>あ・えない</kun>
+			<on>カン</on>
+			<kun>あ・えず</kun>
+		</kanji>
+		<kanji>
+			<char>棺</char>
+			<meaning>Coffin</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>款</char>
+			<meaning>Clause; Article; Stipulation</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>歓</char>
+			<meaning>Joy; Pleasure</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>汗</char>
+			<meaning>Sweat</meaning>
+			<kun>あせ</kun>
+			<on>カン</on>
+			<kun>あせ・ばむ</kun>
+		</kanji>
+		<kanji>
+			<char>環</char>
+			<meaning>Ring; Link; Circle</meaning>
+			<kun>わ</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>甘</char>
+			<meaning>Depend upon; Sweet; Tasty</meaning>
+			<kun>うま・い</kun>
+			<kun>うま・え</kun>
+			<on>カン</on>
+			<kun>あま・んじる</kun>
+			<kun>あま・み</kun>
+			<kun>あま・い</kun>
+			<kun>うま・える</kun>
+			<kun>あま・やかす</kun>
+			<kun>あま・ったるい</kun>
+		</kanji>
+		<kanji>
+			<char>監</char>
+			<meaning>Administrator; Superintendant</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>緩</char>
+			<meaning>Loosen; Relax; Leisurely</meaning>
+			<kun>ゆる・み</kun>
+			<kun>ゆる・める</kun>
+			<on>カン</on>
+			<kun>ゆる・い</kun>
+			<kun>ゆる・む</kun>
+			<kun>ゆる・やか</kun>
+		</kanji>
+		<kanji>
+			<char>缶</char>
+			<meaning>Can; Drum; Kettle</meaning>
+			<kun>かま</kun>
+			<on>カン</on>
+			<kun>ほとぎ</kun>
+		</kanji>
+		<kanji>
+			<char>肝</char>
+			<meaning>Liver</meaning>
+			<kun>きも</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>艦</char>
+			<meaning>Warship</meaning>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>貫</char>
+			<meaning>Pierce; Go through; Unit of weight</meaning>
+			<kun>ぬき</kun>
+			<kun>つらぬ・く</kun>
+			<on>カン</on>
+			<kun>ぬ・く</kun>
+		</kanji>
+		<kanji>
+			<char>還</char>
+			<meaning>Return; Send back</meaning>
+			<kun>かえ・る</kun>
+			<on>カン</on>
+			<kun>かえ・す</kun>
+		</kanji>
+		<kanji>
+			<char>鑑</char>
+			<meaning>Heed; Judgement; Specimen</meaning>
+			<kun>かんが・みる</kun>
+			<on>カン</on>
+			<kun>かがみ</kun>
+		</kanji>
+		<kanji>
+			<char>閑</char>
+			<meaning>Free time; Rest; Leisure</meaning>
+			<kun>ひま</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>陥</char>
+			<meaning>Fall into; Ensnare; Pitfall</meaning>
+			<kun>おちい・る</kun>
+			<on>カン</on>
+			<kun>おとしい・れる</kun>
+		</kanji>
+		<kanji>
+			<char>含</char>
+			<meaning>Soak with; Put in mouth; Contain</meaning>
+			<kun>ふく・ます</kun>
+			<kun>ふく・まれる</kun>
+			<kun>ふく・む</kun>
+			<on>ガン</on>
+			<kun>ふく・ませる</kun>
+			<kun>ふく・める</kun>
+			<kun>ふく・み</kun>
+		</kanji>
+		<kanji>
+			<char>頑</char>
+			<meaning>Obstinate; Stubborn</meaning>
+			<kun>かたくな</kun>
+			<on>ガン</on>
+		</kanji>
+		<kanji>
+			<char>企</char>
+			<meaning>Plan; Plot; Scheme</meaning>
+			<kun>たくら・む</kun>
+			<kun>くわだ・てる</kun>
+			<on>キ</on>
+			<kun>たくら・み</kun>
+			<kun>くわだ・て</kun>
+		</kanji>
+		<kanji>
+			<char>奇</char>
+			<meaning>Peculiar; Mysterious</meaning>
+			<kun>く・しくも</kun>
+			<kun>く・し</kun>
+			<on>キ</on>
+			<kun>く・しき</kun>
+		</kanji>
+		<kanji>
+			<char>岐</char>
+			<meaning>Junction; Crossroads; Fork</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>幾</char>
+			<meaning>Some number; How many; How much</meaning>
+			<kun>いく</kun>
+			<on>キ</on>
+			<kun>いく・つ</kun>
+			<kun>いく・ら</kun>
+		</kanji>
+		<kanji>
+			<char>忌</char>
+			<meaning>Detest; Annoying; Anniversary of death</meaning>
+			<kun>い・まわしい</kun>
+			<kun>い・む</kun>
+			<on>キ</on>
+			<kun>い・み</kun>
+		</kanji>
+		<kanji>
+			<char>既</char>
+			<meaning>Already</meaning>
+			<kun>すで・に</kun>
+			<kun>すんで・に</kun>
+			<on>キ</on>
+			<kun>すんで</kun>
+		</kanji>
+		<kanji>
+			<char>棋</char>
+			<meaning>Shogi; Chess</meaning>
+			<on>ギ</on>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>棄</char>
+			<meaning>Abandon; Throw away; Discard</meaning>
+			<kun>す・てる</kun>
+			<on>キ</on>
+			<kun>すて</kun>
+		</kanji>
+		<kanji>
+			<char>祈</char>
+			<meaning>Pray; Wish</meaning>
+			<kun>いの・り</kun>
+			<on>キ</on>
+			<kun>いの・る</kun>
+		</kanji>
+		<kanji>
+			<char>軌</char>
+			<meaning>Track; Rut; Normal</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>輝</char>
+			<meaning>Shine; Glitter; Radiant</meaning>
+			<kun>かがや・く</kun>
+			<kun>かがや・かしい</kun>
+			<on>キ</on>
+			<kun>かがや・かす</kun>
+			<kun>かがや・き</kun>
+		</kanji>
+		<kanji>
+			<char>飢</char>
+			<meaning>Hunger; Starve; Famine</meaning>
+			<kun>う・える</kun>
+			<on>キ</on>
+			<kun>う・え</kun>
+		</kanji>
+		<kanji>
+			<char>騎</char>
+			<meaning>Horseman; Cavalry</meaning>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>鬼</char>
+			<meaning>Ogre; Demon</meaning>
+			<kun>おに</kun>
+			<on>キ</on>
+		</kanji>
+		<kanji>
+			<char>偽</char>
+			<meaning>Lie; Falsehood; Imitation</meaning>
+			<kun>にせ</kun>
+			<kun>いつわ・り</kun>
+			<on>ギ</on>
+			<kun>いつわ・る</kun>
+		</kanji>
+		<kanji>
+			<char>儀</char>
+			<meaning>Ceremony; Ritual; Incident</meaning>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>宜</char>
+			<meaning>Friendship; Kindness; Very well</meaning>
+			<kun>よろ・しい</kun>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>戯</char>
+			<meaning>Joke; Frolic; Humour</meaning>
+			<kun>そば・える</kun>
+			<kun>おど・ける</kun>
+			<kun>たわむ・れる</kun>
+			<kun>じゃ・れる</kun>
+			<kun>ざれ</kun>
+			<kun>たわむ・れ</kun>
+			<on>ギ</on>
+			<kun>あじゃら</kun>
+			<kun>たわぶ・れる</kun>
+			<kun>ざ・れる</kun>
+			<kun>たわ</kun>
+			<kun>たわ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>擬</char>
+			<meaning>Doubt; Suspicion</meaning>
+			<kun>うたが・う</kun>
+			<on>ギ</on>
+			<kun>うたが・わしい</kun>
+		</kanji>
+		<kanji>
+			<char>欺</char>
+			<meaning>Decieve; Swindle; Fraud</meaning>
+			<kun>あざむ・く</kun>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>犠</char>
+			<meaning>Sacrifice; Victim; Casualty</meaning>
+			<on>ギ</on>
+		</kanji>
+		<kanji>
+			<char>菊</char>
+			<meaning>Chrysanthemum</meaning>
+			<on>キっ</on>
+			<on>キク</on>
+		</kanji>
+		<kanji>
+			<char>吉</char>
+			<meaning>Good luck; Fortunate; Auspicious</meaning>
+			<on>キチ</on>
+			<on>キツ</on>
+			<on>キっ</on>
+		</kanji>
+		<kanji>
+			<char>喫</char>
+			<meaning>Smoke; Breathe in; Sip</meaning>
+			<kun>す・う</kun>
+			<on>キっ</on>
+			<on>キツ</on>
+			<kun>き・する</kun>
+		</kanji>
+		<kanji>
+			<char>詰</char>
+			<meaning>Pack in cans; Block in; In brief</meaning>
+			<on>キっ</on>
+			<kun>つ・まらせる</kun>
+			<kun>つ・める</kun>
+			<kun>つ・め</kun>
+			<kun>なじ・る</kun>
+			<kun>づまり</kun>
+			<on>キツ</on>
+			<kun>づめ</kun>
+			<kun>つ・まり</kun>
+			<kun>つ・まる</kun>
+			<kun>つ・む</kun>
+			<kun>つまり</kun>
+		</kanji>
+		<kanji>
+			<char>却</char>
+			<meaning>On the contrary; Disposal; Erasure</meaning>
+			<on>キャっ</on>
+			<on>キャク</on>
+		</kanji>
+		<kanji>
+			<char>脚</char>
+			<meaning>Leg; Foot</meaning>
+			<on>キャク</on>
+			<kun>あし</kun>
+			<on>カっ</on>
+		</kanji>
+		<kanji>
+			<char>虐</char>
+			<meaning>Oppress; Ill-treat; Bully</meaning>
+			<kun>しいた・げる</kun>
+			<kun>いじ・め</kun>
+			<on>ギャク</on>
+			<kun>いじ・める</kun>
+		</kanji>
+		<kanji>
+			<char>丘</char>
+			<meaning>Hill</meaning>
+			<on>キュウ</on>
+			<kun>おか</kun>
+		</kanji>
+		<kanji>
+			<char>及</char>
+			<meaning>Reach; Success; Also</meaning>
+			<kun>およ・ぶ</kun>
+			<kun>およ・ぼす</kun>
+			<on>キュウ</on>
+			<kun>およ・び</kun>
+		</kanji>
+		<kanji>
+			<char>朽</char>
+			<meaning>Decay; Rot; Perish</meaning>
+			<kun>く・ちる</kun>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>窮</char>
+			<meaning>Come to an end; Investigate thoroughly; Poverty</meaning>
+			<kun>きわ・まる</kun>
+			<kun>きゅう・す</kun>
+			<on>キュウ</on>
+			<kun>きわ・める</kun>
+			<kun>きゅう・する</kun>
+		</kanji>
+		<kanji>
+			<char>糾</char>
+			<meaning>Inquiry; Examination</meaning>
+			<on>キュウ</on>
+		</kanji>
+		<kanji>
+			<char>巨</char>
+			<meaning>Giant; Great; Large</meaning>
+			<on>コ</on>
+			<on>キョ</on>
+		</kanji>
+		<kanji>
+			<char>拒</char>
+			<meaning>Refuse; Reject; Resist</meaning>
+			<kun>こば・む</kun>
+			<on>キョ</on>
+			<kun>つき・む</kun>
+		</kanji>
+		<kanji>
+			<char>拠</char>
+			<meaning>Result from; Foundation; Basis</meaning>
+			<on>コ</on>
+			<on>キョ</on>
+			<kun>よ・る</kun>
+		</kanji>
+		<kanji>
+			<char>虚</char>
+			<meaning>Void; Empty; Null</meaning>
+			<kun>うつ・ろ</kun>
+			<on>キョ</on>
+			<kun>むな・しい</kun>
+		</kanji>
+		<kanji>
+			<char>距</char>
+			<meaning>Long distance</meaning>
+			<on>キョ</on>
+		</kanji>
+		<kanji>
+			<char>享</char>
+			<meaning>Receive; Undertake</meaning>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>凶</char>
+			<meaning>Bad luck; Atrocious; Evil</meaning>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>叫</char>
+			<meaning>Scream; Shout; Clamour</meaning>
+			<kun>わめ・く</kun>
+			<kun>さけ・び</kun>
+			<on>キョウ</on>
+			<kun>さけ・ぶ</kun>
+		</kanji>
+		<kanji>
+			<char>峡</char>
+			<meaning>Ravine; Isthmus; Straits</meaning>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>恐</char>
+			<meaning>Fear; Dreadful; Frightening</meaning>
+			<kun>こわ・い</kun>
+			<kun>おそ・らく</kun>
+			<kun>おそ・ろしい</kun>
+			<kun>おそ・れ</kun>
+			<on>キョウ</on>
+			<kun>こわ・がる</kun>
+			<kun>おそ・れる</kun>
+			<kun>おそ・る</kun>
+		</kanji>
+		<kanji>
+			<char>恭</char>
+			<meaning>Respect; Veneration</meaning>
+			<kun>うやうや・しい</kun>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>挟</char>
+			<meaning>Get between; Interpose; Pincers</meaning>
+			<kun>はさ・み</kun>
+			<on>キョウ</on>
+			<kun>はさ・まる</kun>
+			<kun>はさ・む</kun>
+		</kanji>
+		<kanji>
+			<char>況</char>
+			<meaning>Outlook; Condition; Not to mention</meaning>
+			<kun>ま・して</kun>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>狂</char>
+			<meaning>Go mad; Crazy; Confusion</meaning>
+			<kun>くる・い</kun>
+			<kun>くる・おしい</kun>
+			<on>キョウ</on>
+			<kun>くる・う</kun>
+			<kun>くる・わす</kun>
+		</kanji>
+		<kanji>
+			<char>狭</char>
+			<meaning>Reduce; Contract; Narrow</meaning>
+			<kun>せま・い</kun>
+			<kun>せば・める</kun>
+			<on>キョウ</on>
+			<kun>ぜま</kun>
+			<kun>せば・まる</kun>
+		</kanji>
+		<kanji>
+			<char>矯</char>
+			<meaning>Twist; Straighten; Correct</meaning>
+			<kun>た・める</kun>
+			<on>キョウ</on>
+		</kanji>
+		<kanji>
+			<char>脅</char>
+			<meaning>Threaten; Coerce; Menace</meaning>
+			<kun>おど・かす</kun>
+			<kun>おびや・かす</kun>
+			<kun>おど・す</kun>
+			<on>キョウ</on>
+			<kun>おど・かし</kun>
+			<kun>おど・し</kun>
+		</kanji>
+		<kanji>
+			<char>響</char>
+			<meaning>Reverberate; Echo; Influence</meaning>
+			<kun>ひび・く</kun>
+			<kun>どよ・めく</kun>
+			<on>キョウ</on>
+			<kun>ひび・き</kun>
+			<kun>どよ・めき</kun>
+		</kanji>
+		<kanji>
+			<char>驚</char>
+			<meaning>Astonish; Surprise; Amazement</meaning>
+			<kun>おどろ・かす</kun>
+			<kun>おどろ・き</kun>
+			<on>キョウ</on>
+			<kun>おどろ・く</kun>
+		</kanji>
+		<kanji>
+			<char>仰</char>
+			<meaning>Look up to; Impart; Reverence</meaning>
+			<on>ゴウ</on>
+			<kun>あお・ぐ</kun>
+			<kun>あお・むく</kun>
+			<kun>お・っしゃる</kun>
+			<kun>あお・のける</kun>
+			<kun>の・ける</kun>
+			<on>ギョウ</on>
+			<on>コウ</on>
+			<kun>あお・のく</kun>
+			<kun>おお・せられる</kun>
+			<kun>おお・せ</kun>
+		</kanji>
+		<kanji>
+			<char>凝</char>
+			<meaning>Congeal; Stiffen; Curdle</meaning>
+			<kun>こり</kun>
+			<kun>こ・らす</kun>
+			<kun>こご・る</kun>
+			<kun>こ・る</kun>
+			<kun>こご・らせる</kun>
+			<on>ギョウ</on>
+			<kun>みつ・める</kun>
+			<kun>しこ・る</kun>
+			<kun>こ・り</kun>
+			<kun>こご・らす</kun>
+		</kanji>
+		<kanji>
+			<char>暁</char>
+			<meaning>Daybreak; Dawn</meaning>
+			<on>ギョウ</on>
+			<kun>あかつき</kun>
+		</kanji>
+		<kanji>
+			<char>斤</char>
+			<meaning>Unit of weight</meaning>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>琴</char>
+			<meaning>Koto; Harp</meaning>
+			<on>キン</on>
+			<kun>こと</kun>
+		</kanji>
+		<kanji>
+			<char>緊</char>
+			<meaning>Urgent; Shrinkage; Bindings</meaning>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>菌</char>
+			<meaning>Fungus; Germ; Bacterium</meaning>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>襟</char>
+			<meaning>Neck; Collar</meaning>
+			<on>キン</on>
+			<kun>えり</kun>
+		</kanji>
+		<kanji>
+			<char>謹</char>
+			<meaning>Have discretion; Respectful; Discreet</meaning>
+			<kun>つつし・む</kun>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>吟</char>
+			<meaning>Recite poetry; Singing; Chanting</meaning>
+			<on>ギン</on>
+			<on>キン</on>
+		</kanji>
+		<kanji>
+			<char>駆</char>
+			<meaning>Ride; Drive; Run a race</meaning>
+			<kun>が・ける</kun>
+			<kun>か・られる</kun>
+			<on>ク</on>
+			<kun>か・る</kun>
+		</kanji>
+		<kanji>
+			<char>愚</char>
+			<meaning>Foolish; Stupid</meaning>
+			<kun>おろ・か</kun>
+			<on>グ</on>
+			<kun>おろ・かしい</kun>
+		</kanji>
+		<kanji>
+			<char>虞</char>
+			<meaning>Fear; Anxiety</meaning>
+			<on>グ</on>
+			<kun>おそれ</kun>
+		</kanji>
+		<kanji>
+			<char>偶</char>
+			<meaning>Doll; Idol; By chance</meaning>
+			<kun>たま</kun>
+			<on>グウ</on>
+			<kun>たま・さか</kun>
+		</kanji>
+		<kanji>
+			<char>遇</char>
+			<meaning>Meeting; Encounter</meaning>
+			<on>グウ</on>
+		</kanji>
+		<kanji>
+			<char>隅</char>
+			<meaning>Corner; Nook</meaning>
+			<kun>すみ</kun>
+			<on>グウ</on>
+		</kanji>
+		<kanji>
+			<char>屈</char>
+			<meaning>Yield; Stoop; Lean over</meaning>
+			<kun>く・する</kun>
+			<kun>かが・める</kun>
+			<on>クツ</on>
+			<kun>かが・む</kun>
+			<on>クっ</on>
+		</kanji>
+		<kanji>
+			<char>掘</char>
+			<meaning>Dig; Excavation</meaning>
+			<kun>ほ・る</kun>
+			<kun>ほり</kun>
+			<on>クツ</on>
+			<on>クっ</on>
+		</kanji>
+		<kanji>
+			<char>靴</char>
+			<meaning>Boots; Shoes</meaning>
+			<on>グツ</on>
+			<on>クツ</on>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>繰</char>
+			<meaning>Reel; Wind; Put forward</meaning>
+			<kun>くり</kun>
+			<kun>く・る</kun>
+		</kanji>
+		<kanji>
+			<char>桑</char>
+			<meaning>Mulberry tree</meaning>
+			<on>ソウ</on>
+			<kun>くわ</kun>
+		</kanji>
+		<kanji>
+			<char>勲</char>
+			<meaning>Medal; Decoration; Honours</meaning>
+			<kun>いさお</kun>
+			<on>クン</on>
+		</kanji>
+		<kanji>
+			<char>薫</char>
+			<meaning>Smell sweet; Fragrance</meaning>
+			<kun>かお・る</kun>
+			<on>クン</on>
+			<kun>かお・り</kun>
+		</kanji>
+		<kanji>
+			<char>傾</char>
+			<meaning>Slant; Be prone to; Set (sun, moon)</meaning>
+			<kun>かたむ・く</kun>
+			<kun>かたぶ・く</kun>
+			<kun>かた・げる</kun>
+			<kun>かし・げる</kun>
+			<kun>なだ・る</kun>
+			<kun>かた・ぐ</kun>
+			<on>ケイ</on>
+			<kun>かたむ・き</kun>
+			<kun>なだ・れる</kun>
+			<kun>かたむ・ける</kun>
+			<kun>かし・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>刑</char>
+			<meaning>Punishment; Penalty; Sentence</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>啓</char>
+			<meaning>Enlighten; Edify; Revelation</meaning>
+			<kun>ひら・く</kun>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>契</char>
+			<meaning>Pledge; Contract; Oath</meaning>
+			<kun>ちぎ・る</kun>
+			<kun>ちぎ・り</kun>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>恵</char>
+			<meaning>Bless; Grace; Benefit</meaning>
+			<on>エ</on>
+			<kun>めぐ・む</kun>
+			<on>ケイ</on>
+			<kun>めぐ・まれる</kun>
+			<kun>めぐ・み</kun>
+		</kanji>
+		<kanji>
+			<char>慶</char>
+			<meaning>Rejoice; Be happy</meaning>
+			<kun>よろこ・ぶ</kun>
+			<on>ケイ</on>
+			<kun>よろこ・び</kun>
+		</kanji>
+		<kanji>
+			<char>憩</char>
+			<meaning>Rest; Relax</meaning>
+			<kun>いこ・い</kun>
+			<kun>いこい</kun>
+			<kun>いこ・う</kun>
+		</kanji>
+		<kanji>
+			<char>掲</char>
+			<meaning>Publish; Hoist a flag; The aforementioned</meaning>
+			<kun>かか・げる</kun>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>携</char>
+			<meaning>Carry; Participate</meaning>
+			<kun>たずさ・わる</kun>
+			<on>ケイ</on>
+			<kun>たずさ・える</kun>
+		</kanji>
+		<kanji>
+			<char>渓</char>
+			<meaning>Ravine; Canyon</meaning>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>継</char>
+			<meaning>Inherit; Successor; Step relation</meaning>
+			<kun>つ・ぐ</kun>
+			<kun>つ・ぎ</kun>
+			<on>ケイ</on>
+			<kun>つぎ</kun>
+		</kanji>
+		<kanji>
+			<char>茎</char>
+			<meaning>Stem; Stalk</meaning>
+			<kun>くき</kun>
+			<on>ケイ</on>
+		</kanji>
+		<kanji>
+			<char>蛍</char>
+			<meaning>Firefly</meaning>
+			<on>ケイ</on>
+			<kun>ほたる</kun>
+		</kanji>
+		<kanji>
+			<char>鶏</char>
+			<meaning>Hen; Chicken</meaning>
+			<kun>かけ</kun>
+			<kun>とり</kun>
+			<kun>くだかけ</kun>
+			<on>ケイ</on>
+			<kun>くたかけ</kun>
+			<kun>にわとり</kun>
+		</kanji>
+		<kanji>
+			<char>迎</char>
+			<meaning>Meet; Welcome; Invite</meaning>
+			<kun>むか・え</kun>
+			<on>ゲイ</on>
+			<kun>むか・える</kun>
+		</kanji>
+		<kanji>
+			<char>鯨</char>
+			<meaning>Whale</meaning>
+			<on>ゲイ</on>
+			<kun>くじら</kun>
+		</kanji>
+		<kanji>
+			<char>撃</char>
+			<meaning>Shoot; Attack; Hit</meaning>
+			<kun>う・つ</kun>
+			<kun>げき</kun>
+		</kanji>
+		<kanji>
+			<char>傑</char>
+			<meaning>Excel; Outstanding; Greatness</meaning>
+			<kun>すぐ・れる</kun>
+			<on>ケツ</on>
+			<on>ケっ</on>
+		</kanji>
+		<kanji>
+			<char>倹</char>
+			<meaning>Economy; Frugality; Thrift</meaning>
+			<kun>つま・しい</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>兼</char>
+			<meaning>Combine with; Be unable to; Hesitate to</meaning>
+			<kun>けん・す</kun>
+			<on>ケン</on>
+			<kun>か・ねる</kun>
+		</kanji>
+		<kanji>
+			<char>剣</char>
+			<meaning>Sword</meaning>
+			<kun>つるぎ</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>圏</char>
+			<meaning>Sphere; Circle; Zone</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>堅</char>
+			<meaning>Harden; Firm; Solid</meaning>
+			<kun>かた・い</kun>
+			<kun>かた・める</kun>
+			<on>ケン</on>
+			<kun>かた・さ</kun>
+			<kun>かた</kun>
+		</kanji>
+		<kanji>
+			<char>嫌</char>
+			<meaning>Dislike; Hate; Disagreeable</meaning>
+			<on>ゲン</on>
+			<kun>きら・う</kun>
+			<on>ケン</on>
+			<kun>いや・がる</kun>
+			<kun>いや</kun>
+			<kun>きら・い</kun>
+			<kun>いや・らしい</kun>
+			<kun>いや・がらせ</kun>
+		</kanji>
+		<kanji>
+			<char>懸</char>
+			<meaning>Suspend from; Offer a prize; Stake one's life</meaning>
+			<kun>か・かる</kun>
+			<kun>かけ</kun>
+			<on>ケン</on>
+			<kun>か・ける</kun>
+		</kanji>
+		<kanji>
+			<char>献</char>
+			<meaning>Offering; Dedication; Donation</meaning>
+			<on>ケン</on>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>肩</char>
+			<meaning>Shoulder</meaning>
+			<on>ケン</on>
+			<kun>かた</kun>
+		</kanji>
+		<kanji>
+			<char>謙</char>
+			<meaning>Be humble; Modesty</meaning>
+			<kun>へりくだ・る</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>賢</char>
+			<meaning>Clever; Wisdom</meaning>
+			<kun>かしこ・い</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>軒</char>
+			<meaning>House; Eaves</meaning>
+			<kun>のき</kun>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>遣</char>
+			<meaning>Dispatch; Do; Errand</meaning>
+			<kun>や・られる</kun>
+			<kun>つか・わす</kun>
+			<on>ケン</on>
+			<kun>や・る</kun>
+			<kun>つか・い</kun>
+		</kanji>
+		<kanji>
+			<char>顕</char>
+			<meaning>Manifestation; Revelation</meaning>
+			<on>ケン</on>
+		</kanji>
+		<kanji>
+			<char>幻</char>
+			<meaning>Phantom; Apparition; Illusion</meaning>
+			<kun>まぼろし</kun>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>弦</char>
+			<meaning>Bow string; Instrument string</meaning>
+			<kun>つる</kun>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>玄</char>
+			<meaning>Arcane; Profound</meaning>
+			<on>ゲン</on>
+		</kanji>
+		<kanji>
+			<char>孤</char>
+			<meaning>Solitary; Orphan</meaning>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>弧</char>
+			<meaning>Arc</meaning>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>枯</char>
+			<meaning>Wither; Dry up; Season lumber</meaning>
+			<kun>か・らす</kun>
+			<on>コ</on>
+			<kun>か・れる</kun>
+		</kanji>
+		<kanji>
+			<char>誇</char>
+			<meaning>Take pride; Boast of</meaning>
+			<kun>ほこ・り</kun>
+			<on>コ</on>
+			<kun>ほこ・る</kun>
+			<kun>ほこ・らしい</kun>
+		</kanji>
+		<kanji>
+			<char>雇</char>
+			<meaning>Hire; Employ</meaning>
+			<kun>やと・う</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>顧</char>
+			<meaning>Look back; Patron</meaning>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>鼓</char>
+			<meaning>Drum</meaning>
+			<kun>つづみ</kun>
+			<on>コ</on>
+		</kanji>
+		<kanji>
+			<char>互</char>
+			<meaning>Mutual; Reciprocal</meaning>
+			<kun>たが・い</kun>
+			<on>ゴ</on>
+			<kun>かたみ・に</kun>
+		</kanji>
+		<kanji>
+			<char>呉</char>
+			<meaning>Give; Do for someone</meaning>
+			<kun>く・れる</kun>
+			<on>ゴ</on>
+			<kun>くれ</kun>
+		</kanji>
+		<kanji>
+			<char>娯</char>
+			<meaning>Recreation</meaning>
+			<on>ゴ</on>
+		</kanji>
+		<kanji>
+			<char>御</char>
+			<meaning>Honourable</meaning>
+			<on>ギョ</on>
+			<kun>おん</kun>
+			<on>ゴ</on>
+			<kun>お</kun>
+		</kanji>
+		<kanji>
+			<char>悟</char>
+			<meaning>Comprehend; Perceive</meaning>
+			<kun>さと・る</kun>
+			<on>ゴ</on>
+			<kun>さと・り</kun>
+		</kanji>
+		<kanji>
+			<char>碁</char>
+			<meaning>The game of Go</meaning>
+			<on>ゴ</on>
+		</kanji>
+		<kanji>
+			<char>侯</char>
+			<meaning>Prince; Lord</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>坑</char>
+			<meaning>Mine; Pit</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>孔</char>
+			<meaning>Pore; Hole</meaning>
+			<kun>あな</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>巧</char>
+			<meaning>Be skillful; Technique; Skill</meaning>
+			<kun>うま・い</kun>
+			<kun>たく・み</kun>
+			<on>コウ</on>
+			<kun>たく・む</kun>
+		</kanji>
+		<kanji>
+			<char>恒</char>
+			<meaning>Constant; Perpetual</meaning>
+			<kun>つね</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>慌</char>
+			<meaning>Lose composure; Flustered; Impatient</meaning>
+			<kun>あわ・てる</kun>
+			<kun>あわ・つ</kun>
+			<on>コウ</on>
+			<kun>あわ・ただしい</kun>
+		</kanji>
+		<kanji>
+			<char>抗</char>
+			<meaning>Resistance; Objection; Opposition</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>拘</char>
+			<meaning>Concern oneself with; Detention; Confinement</meaning>
+			<on>コウ</on>
+			<kun>かか・わる</kun>
+		</kanji>
+		<kanji>
+			<char>控</char>
+			<meaning>Refrain from; Cut back on; Take a note of</meaning>
+			<kun>ひ・かえ</kun>
+			<kun>ひかえ・る</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>攻</char>
+			<meaning>Attack; Assault; Aggression</meaning>
+			<kun>せ・める</kun>
+			<on>コウ</on>
+			<kun>せ・め</kun>
+		</kanji>
+		<kanji>
+			<char>更</char>
+			<meaning>Get late; Stay up late; Night watch</meaning>
+			<kun>さら</kun>
+			<kun>ふ・ける</kun>
+			<on>コウ</on>
+			<kun>ふ・かす</kun>
+		</kanji>
+		<kanji>
+			<char>江</char>
+			<meaning>Inlet; Bay; Creek</meaning>
+			<kun>え</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>洪</char>
+			<meaning>Flood</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>溝</char>
+			<meaning>Furrow; Ditch; 10^38</meaning>
+			<kun>どぶ</kun>
+			<kun>せせなぎ</kun>
+			<on>コウ</on>
+			<kun>みぞ</kun>
+		</kanji>
+		<kanji>
+			<char>甲</char>
+			<meaning>Shell; Armour; High pitch</meaning>
+			<kun>きのえ</kun>
+			<on>コン</on>
+			<on>コウ</on>
+			<on>カン</on>
+			<on>カ</on>
+		</kanji>
+		<kanji>
+			<char>硬</char>
+			<meaning>Hard; Stiff; Solid</meaning>
+			<kun>かた・い</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>稿</char>
+			<meaning>Manuscript; Draft</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>絞</char>
+			<meaning>Strangle; Wring; Constrict</meaning>
+			<kun>し・まる</kun>
+			<kun>しぼ・り</kun>
+			<kun>し・める</kun>
+			<kun>しぼ・る</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>綱</char>
+			<meaning>Rope; Line</meaning>
+			<kun>つな</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>肯</char>
+			<meaning>Acknowledge; Affirm; Assent</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>荒</char>
+			<meaning>Lay waste; Fall to ruin; Wilderness</meaning>
+			<kun>あら</kun>
+			<kun>あ・らす</kun>
+			<on>コウ</on>
+			<kun>あら・い</kun>
+			<kun>あ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>衡</char>
+			<meaning>Equilibrium; Equality; Balance</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>貢</char>
+			<meaning>Pay support; Tribute; Tax</meaning>
+			<kun>みつ・ぐ</kun>
+			<on>コウ</on>
+			<kun>みつ・ぎ</kun>
+		</kanji>
+		<kanji>
+			<char>購</char>
+			<meaning>Subscription; Purchase</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>郊</char>
+			<meaning>Outskirts; Suburbs</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>酵</char>
+			<meaning>Fermentation</meaning>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>項</char>
+			<meaning>Clause; Item; Nape</meaning>
+			<kun>うなじ</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>香</char>
+			<meaning>Emit fragrance; Perfume; Incense</meaning>
+			<on>カ</on>
+			<kun>かお・る</kun>
+			<on>コウ</on>
+			<on>ガ</on>
+			<kun>かお・り</kun>
+		</kanji>
+		<kanji>
+			<char>剛</char>
+			<meaning>Vigour; Bravery; Integrity</meaning>
+			<on>ゴウ</on>
+		</kanji>
+		<kanji>
+			<char>拷</char>
+			<meaning>Torture</meaning>
+			<on>ゴウ</on>
+		</kanji>
+		<kanji>
+			<char>豪</char>
+			<meaning>Veteran; Wealthy; Australia</meaning>
+			<on>ゴウ</on>
+		</kanji>
+		<kanji>
+			<char>克</char>
+			<meaning>Overcome; Subjugation</meaning>
+			<on>コっ</on>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>酷</char>
+			<meaning>Cruel; Severe; Terrible</meaning>
+			<kun>ひど・い</kun>
+			<on>コク</on>
+		</kanji>
+		<kanji>
+			<char>獄</char>
+			<meaning>Prison; Jail</meaning>
+			<on>ゴク</on>
+		</kanji>
+		<kanji>
+			<char>腰</char>
+			<meaning>Hips; Waist; Loins</meaning>
+			<kun>こし</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>込</char>
+			<meaning>Crowd; Put into</meaning>
+			<kun>こみ</kun>
+			<kun>こ・む</kun>
+			<kun>こ・める</kun>
+		</kanji>
+		<kanji>
+			<char>墾</char>
+			<meaning>Cultivated land</meaning>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>婚</char>
+			<meaning>Marriage</meaning>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>恨</char>
+			<meaning>Bear a grudge; Resent; Regret</meaning>
+			<kun>うら・む</kun>
+			<kun>うら・めしい</kun>
+			<on>コン</on>
+			<kun>うら・み</kun>
+		</kanji>
+		<kanji>
+			<char>懇</char>
+			<meaning>Familiarity; Courtesy; Cordiality</meaning>
+			<kun>ねんご・ろ</kun>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>昆</char>
+			<meaning>Insect</meaning>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>紺</char>
+			<meaning>Dark blue</meaning>
+			<on>コン</on>
+		</kanji>
+		<kanji>
+			<char>魂</char>
+			<meaning>Soul; Spirit</meaning>
+			<kun>たま</kun>
+			<on>コン</on>
+			<kun>たましい</kun>
+		</kanji>
+		<kanji>
+			<char>佐</char>
+			<meaning>Assistance; Aid; Military rank</meaning>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>唆</char>
+			<meaning>Instigate; Suggest</meaning>
+			<kun>そそのか・す</kun>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>詐</char>
+			<meaning>Deceive; Swindle; Exploit</meaning>
+			<kun>いつわ・る</kun>
+			<on>サ</on>
+		</kanji>
+		<kanji>
+			<char>鎖</char>
+			<meaning>Chain; Close</meaning>
+			<on>サ</on>
+			<kun>くさり</kun>
+			<kun>とざ・す</kun>
+		</kanji>
+		<kanji>
+			<char>債</char>
+			<meaning>Debt; Loan</meaning>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>催</char>
+			<meaning>Hold a meeting; Show signs of</meaning>
+			<kun>もよお・す</kun>
+			<on>サイ</on>
+			<kun>もよお・し</kun>
+		</kanji>
+		<kanji>
+			<char>宰</char>
+			<meaning>Chairman</meaning>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>彩</char>
+			<meaning>Colour; Brilliant; Conspicuous</meaning>
+			<kun>いろど・り</kun>
+			<on>サイ</on>
+			<kun>いろど・る</kun>
+		</kanji>
+		<kanji>
+			<char>栽</char>
+			<meaning>Planting</meaning>
+			<on>ザイ</on>
+			<on>サイ</on>
+		</kanji>
+		<kanji>
+			<char>歳</char>
+			<meaning>Year; Years old; Annual</meaning>
+			<on>ザイ</on>
+			<on>サイ</on>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>砕</char>
+			<meaning>Smash; Break; Pulverise</meaning>
+			<kun>くだ・く</kun>
+			<kun>くだ・け</kun>
+			<on>サイ</on>
+			<kun>くだ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>斎</char>
+			<meaning>Enshrine; Shun; Purification</meaning>
+			<kun>とき</kun>
+			<kun>いみ</kun>
+			<kun>いつき</kun>
+			<kun>いわい</kun>
+			<on>サイ</on>
+			<kun>ゆ</kun>
+			<kun>いつ・く</kun>
+			<kun>い・む</kun>
+		</kanji>
+		<kanji>
+			<char>載</char>
+			<meaning>Print; Reproduce; 10^44</meaning>
+			<on>ザイ</on>
+			<kun>の・せる</kun>
+			<on>サイ</on>
+			<kun>の・る</kun>
+		</kanji>
+		<kanji>
+			<char>剤</char>
+			<meaning>Medicine; Compound; Chemical agent</meaning>
+			<on>ザイ</on>
+		</kanji>
+		<kanji>
+			<char>咲</char>
+			<meaning>Bloom; Come into flower</meaning>
+			<kun>さ・く</kun>
+		</kanji>
+		<kanji>
+			<char>崎</char>
+			<meaning>Promontory; Spit</meaning>
+			<kun>みさき</kun>
+			<kun>さき</kun>
+		</kanji>
+		<kanji>
+			<char>削</char>
+			<meaning>Slice off; Pare down; Scrape</meaning>
+			<kun>そ・ぐ</kun>
+			<kun>はつ・る</kun>
+			<on>サク</on>
+			<kun>けず・る</kun>
+			<on>サっ</on>
+		</kanji>
+		<kanji>
+			<char>搾</char>
+			<meaning>Squeeze; Press; Compression</meaning>
+			<kun>しぼ・る</kun>
+			<on>サク</on>
+			<kun>しぼ・り</kun>
+		</kanji>
+		<kanji>
+			<char>索</char>
+			<meaning>Rope; Cord</meaning>
+			<on>サク</on>
+		</kanji>
+		<kanji>
+			<char>錯</char>
+			<meaning>Complication; Confusion; Mixed up</meaning>
+			<on>シャク</on>
+			<on>サク</on>
+			<on>サっ</on>
+		</kanji>
+		<kanji>
+			<char>撮</char>
+			<meaning>Pinch; Take a photo</meaning>
+			<kun>と・る</kun>
+			<kun>つま・む</kun>
+			<on>サツ</on>
+			<kun>つま・み</kun>
+		</kanji>
+		<kanji>
+			<char>擦</char>
+			<meaning>Scrub; Chafe; Trace</meaning>
+			<kun>す・る</kun>
+			<kun>かす・る</kun>
+			<kun>なぞ・る</kun>
+			<kun>さす・る</kun>
+			<on>サツ</on>
+			<kun>こす・る</kun>
+			<kun>なす・る</kun>
+			<kun>す・れる</kun>
+		</kanji>
+		<kanji>
+			<char>傘</char>
+			<meaning>Umbrella</meaning>
+			<on>サン</on>
+			<kun>かさ</kun>
+		</kanji>
+		<kanji>
+			<char>惨</char>
+			<meaning>Miserable; Merciless; Pitiful</meaning>
+			<kun>むご・い</kun>
+			<on>ザン</on>
+			<on>サン</on>
+			<kun>みじ・め</kun>
+		</kanji>
+		<kanji>
+			<char>桟</char>
+			<meaning>Jetty; Pier; Wharf</meaning>
+			<on>サン</on>
+		</kanji>
+		<kanji>
+			<char>暫</char>
+			<meaning>A short while; Temporary</meaning>
+			<on>ザン</on>
+			<kun>しばら・く</kun>
+		</kanji>
+		<kanji>
+			<char>伺</char>
+			<meaning>Inquire; Visit</meaning>
+			<kun>うかが・う</kun>
+			<on>シ</on>
+			<kun>うかが・い</kun>
+		</kanji>
+		<kanji>
+			<char>刺</char>
+			<meaning>Pierce; Thorn; Calling card</meaning>
+			<on>シ</on>
+			<kun>とげ</kun>
+			<kun>さ・される</kun>
+			<kun>さ・す</kun>
+			<kun>いら</kun>
+			<kun>さし</kun>
+			<kun>さ・さる</kun>
+			<kun>さ・し</kun>
+		</kanji>
+		<kanji>
+			<char>嗣</char>
+			<meaning>Heir; Successor</meaning>
+			<kun>つぎ</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>施</char>
+			<meaning>Donate; Alms</meaning>
+			<kun>ほどこ・す</kun>
+			<kun>ほどこ・し</kun>
+			<on>シ</on>
+			<on>セ</on>
+		</kanji>
+		<kanji>
+			<char>旨</char>
+			<meaning>A principle; Instructions; Delicious</meaning>
+			<kun>むね</kun>
+			<kun>うま・い</kun>
+			<on>シ</on>
+			<on>ジ</on>
+			<kun>うま</kun>
+		</kanji>
+		<kanji>
+			<char>祉</char>
+			<meaning>Welfare; Assistance</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>紫</char>
+			<meaning>Purple; Violet</meaning>
+			<kun>むらさき</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>肢</char>
+			<meaning>Hands and feet; Extremities</meaning>
+			<kun>え</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>脂</char>
+			<meaning>Fat; Oil; Resin</meaning>
+			<on>シ</on>
+			<kun>やに</kun>
+			<kun>あぶら</kun>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>諮</char>
+			<meaning>Confer with; Refer to; Enquiry</meaning>
+			<kun>はか・る</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>賜</char>
+			<meaning>Bestow; Grant; Gift</meaning>
+			<kun>たま・う</kun>
+			<on>シ</on>
+			<kun>たま・わる</kun>
+		</kanji>
+		<kanji>
+			<char>雌</char>
+			<meaning>Female animal; Feminine</meaning>
+			<kun>めす</kun>
+			<kun>めん</kun>
+			<on>シ</on>
+			<kun>め</kun>
+		</kanji>
+		<kanji>
+			<char>侍</char>
+			<meaning>Samurai; Attendant</meaning>
+			<kun>さむらい</kun>
+			<on>ジ</on>
+			<kun>はべ・る</kun>
+		</kanji>
+		<kanji>
+			<char>慈</char>
+			<meaning>Be affectionate; Be kind to; Love</meaning>
+			<kun>いつく・しむ</kun>
+			<on>ジ</on>
+			<kun>いつく・しみ</kun>
+		</kanji>
+		<kanji>
+			<char>滋</char>
+			<meaning>Nourishment</meaning>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>璽</char>
+			<meaning>Imperial seal</meaning>
+			<on>ジ</on>
+		</kanji>
+		<kanji>
+			<char>軸</char>
+			<meaning>Shaft; Stalk; Axis</meaning>
+			<on>ジク</on>
+		</kanji>
+		<kanji>
+			<char>執</char>
+			<meaning>Hold; Take; Grasp</meaning>
+			<on>シツ</on>
+			<on>シっ</on>
+			<on>シュウ</on>
+			<kun>と・る</kun>
+		</kanji>
+		<kanji>
+			<char>湿</char>
+			<meaning>Moisten; Become wet; Humidity</meaning>
+			<kun>しめ・す</kun>
+			<on>シツ</on>
+			<kun>しめ・る</kun>
+		</kanji>
+		<kanji>
+			<char>漆</char>
+			<meaning>Varnish; Lacquer</meaning>
+			<on>シツ</on>
+			<kun>うるし</kun>
+			<on>シっ</on>
+		</kanji>
+		<kanji>
+			<char>疾</char>
+			<meaning>Already; Rapid</meaning>
+			<kun>と・う</kun>
+			<on>シツ</on>
+		</kanji>
+		<kanji>
+			<char>芝</char>
+			<meaning>Lawn; Turf</meaning>
+			<kun>しば</kun>
+		</kanji>
+		<kanji>
+			<char>赦</char>
+			<meaning>Amnesty; Pardon</meaning>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>斜</char>
+			<meaning>Oblique; Slanting</meaning>
+			<kun>なな・め</kun>
+			<on>シャ</on>
+		</kanji>
+		<kanji>
+			<char>煮</char>
+			<meaning>Boil; Cook; Dish of food</meaning>
+			<kun>に・える</kun>
+			<kun>に・る</kun>
+			<kun>に</kun>
+			<kun>に・やす</kun>
+		</kanji>
+		<kanji>
+			<char>遮</char>
+			<meaning>Obstruct; Intercept; Blockage</meaning>
+			<kun>さえぎ・る</kun>
+		</kanji>
+		<kanji>
+			<char>蛇</char>
+			<meaning>Snake</meaning>
+			<on>ダ</on>
+			<kun>くちなわ</kun>
+			<on>ジャ</on>
+			<kun>へび</kun>
+			<kun>へみ</kun>
+		</kanji>
+		<kanji>
+			<char>邪</char>
+			<meaning>Wicked; Evil</meaning>
+			<kun>よこしま</kun>
+			<on>ジャ</on>
+		</kanji>
+		<kanji>
+			<char>勺</char>
+			<meaning>Unit of volume</meaning>
+			<on>シャク</on>
+		</kanji>
+		<kanji>
+			<char>爵</char>
+			<meaning>Peerage</meaning>
+			<on>シャク</on>
+		</kanji>
+		<kanji>
+			<char>酌</char>
+			<meaning>Serve drink; Drinking; Allowances</meaning>
+			<on>ジャク</on>
+			<on>シャク</on>
+			<kun>く・む</kun>
+		</kanji>
+		<kanji>
+			<char>釈</char>
+			<meaning>Explanation; Interpretation; Annotation</meaning>
+			<on>シャク</on>
+		</kanji>
+		<kanji>
+			<char>寂</char>
+			<meaning>Decline; Desolate; Lonely</meaning>
+			<kun>さび</kun>
+			<kun>さび・しい</kun>
+			<on>ジャク</on>
+			<on>セキ</on>
+			<kun>さみ・しい</kun>
+		</kanji>
+		<kanji>
+			<char>朱</char>
+			<meaning>Scarlet; Bloody</meaning>
+			<kun>あけ</kun>
+			<on>シュ</on>
+		</kanji>
+		<kanji>
+			<char>殊</char>
+			<meaning>Distinctive; Especially</meaning>
+			<on>シュ</on>
+			<on>ジョ</on>
+			<kun>こと</kun>
+		</kanji>
+		<kanji>
+			<char>狩</char>
+			<meaning>Hunt</meaning>
+			<kun>か・る</kun>
+			<on>シュ</on>
+			<kun>か・り</kun>
+		</kanji>
+		<kanji>
+			<char>珠</char>
+			<meaning>Pearl</meaning>
+			<on>ジュ</on>
+			<on>シュ</on>
+			<kun>たま</kun>
+		</kanji>
+		<kanji>
+			<char>趣</char>
+			<meaning>Proceed; Meaning; Gist</meaning>
+			<kun>おもむき</kun>
+			<kun>おもぶき</kun>
+			<on>シュ</on>
+			<kun>おもむけ</kun>
+		</kanji>
+		<kanji>
+			<char>儒</char>
+			<meaning>Confucianism</meaning>
+			<on>ジュ</on>
+		</kanji>
+		<kanji>
+			<char>寿</char>
+			<meaning>Congratulate; Longevity</meaning>
+			<kun>ことぶき</kun>
+			<kun>ことぶ・く</kun>
+			<on>ジュ</on>
+			<kun>ことほぎ</kun>
+		</kanji>
+		<kanji>
+			<char>需</char>
+			<meaning>Requirements; Demand</meaning>
+			<on>ジュ</on>
+		</kanji>
+		<kanji>
+			<char>囚</char>
+			<meaning>Be captured; Prisoner</meaning>
+			<kun>とら・われる</kun>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>愁</char>
+			<meaning>Grieve; Unhappy; Sorrow</meaning>
+			<kun>うれ・い</kun>
+			<on>シュウ</on>
+			<kun>うる・える</kun>
+		</kanji>
+		<kanji>
+			<char>秀</char>
+			<meaning>Excel; Superior</meaning>
+			<kun>ひい・でる</kun>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>臭</char>
+			<meaning>Smell; Stink; Stench</meaning>
+			<kun>くさ・い</kun>
+			<kun>にお・う</kun>
+			<on>シュウ</on>
+			<kun>にお・い</kun>
+		</kanji>
+		<kanji>
+			<char>舟</char>
+			<meaning>Boat</meaning>
+			<on>シュウ</on>
+			<kun>ふな</kun>
+			<kun>ふね</kun>
+			<on>カン</on>
+		</kanji>
+		<kanji>
+			<char>襲</char>
+			<meaning>Attack</meaning>
+			<kun>おそ・う</kun>
+			<on>シュウ</on>
+			<kun>おそい</kun>
+		</kanji>
+		<kanji>
+			<char>酬</char>
+			<meaning>Repay a kindness; Remuneration</meaning>
+			<kun>むく・いる</kun>
+			<on>シュウ</on>
+		</kanji>
+		<kanji>
+			<char>醜</char>
+			<meaning>Ugly; Plain; Disgraceful</meaning>
+			<kun>みにく・い</kun>
+			<on>シュウ</on>
+			<kun>しこ</kun>
+		</kanji>
+		<kanji>
+			<char>充</char>
+			<meaning>Allot; Set aside; Fill up</meaning>
+			<kun>あ・てる</kun>
+			<on>ジュウ</on>
+			<kun>み・たす</kun>
+		</kanji>
+		<kanji>
+			<char>柔</char>
+			<meaning>Gentle; Limp; Meek</meaning>
+			<kun>やわ・らか</kun>
+			<on>ジュウ</on>
+			<kun>やわら・かい</kun>
+		</kanji>
+		<kanji>
+			<char>汁</char>
+			<meaning>Soup; Juice; Sap</meaning>
+			<kun>しる</kun>
+			<on>ジュウ</on>
+			<kun>つゆ</kun>
+		</kanji>
+		<kanji>
+			<char>渋</char>
+			<meaning>Be reluctant; Astringent; Tasteful</meaning>
+			<kun>しぶ</kun>
+			<kun>しぶ・る</kun>
+			<on>ジュウ</on>
+			<kun>しぶ・い</kun>
+		</kanji>
+		<kanji>
+			<char>獣</char>
+			<meaning>Animal; Beast; Brute</meaning>
+			<kun>けだもの</kun>
+			<on>ジュウ</on>
+			<kun>けもの</kun>
+		</kanji>
+		<kanji>
+			<char>銃</char>
+			<meaning>Gun; Rifle</meaning>
+			<on>ジュウ</on>
+		</kanji>
+		<kanji>
+			<char>叔</char>
+			<meaning>Uncle; Aunt</meaning>
+			<on>シュク</on>
+		</kanji>
+		<kanji>
+			<char>淑</char>
+			<meaning>Graceful; Virtue</meaning>
+			<kun>とし・やか</kun>
+			<on>シュク</on>
+		</kanji>
+		<kanji>
+			<char>粛</char>
+			<meaning>Solemn; Purge</meaning>
+			<on>シュク</on>
+		</kanji>
+		<kanji>
+			<char>塾</char>
+			<meaning>Private school; Cram school</meaning>
+			<on>ジュク</on>
+		</kanji>
+		<kanji>
+			<char>俊</char>
+			<meaning>Excellent; Genius; Above average</meaning>
+			<on>シュン</on>
+		</kanji>
+		<kanji>
+			<char>瞬</char>
+			<meaning>Flicker; Twinkle; Wink</meaning>
+			<kun>またた・き</kun>
+			<kun>めばた・き</kun>
+			<kun>まばた・く</kun>
+			<kun>しばたた・く</kun>
+			<on>シュン</on>
+			<kun>まばた・き</kun>
+			<kun>またた・く</kun>
+			<kun>しばた・く</kun>
+		</kanji>
+		<kanji>
+			<char>准</char>
+			<meaning>Associate; Junior; Assistant</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>循</char>
+			<meaning>Circulation</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>旬</char>
+			<meaning>Season; Ten day period</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>殉</char>
+			<meaning>Martyr</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>潤</char>
+			<meaning>Moisten; Profit by; Lubrication</meaning>
+			<kun>うるお・う</kun>
+			<kun>うる・む</kun>
+			<on>ジュン</on>
+			<kun>うるお・い</kun>
+			<kun>うる</kun>
+		</kanji>
+		<kanji>
+			<char>盾</char>
+			<meaning>Shield; Pretext</meaning>
+			<on>ジュン</on>
+			<kun>たて</kun>
+		</kanji>
+		<kanji>
+			<char>巡</char>
+			<meaning>Go around; Patrol; Tour</meaning>
+			<kun>めぐ・る</kun>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>遵</char>
+			<meaning>Obedience</meaning>
+			<on>ジュン</on>
+		</kanji>
+		<kanji>
+			<char>庶</char>
+			<meaning>Common; Ordinary; Illegitimate</meaning>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>緒</char>
+			<meaning>Thong; Beginning</meaning>
+			<kun>お</kun>
+			<on>ショ</on>
+		</kanji>
+		<kanji>
+			<char>叙</char>
+			<meaning>Depict; Confer; Investiture</meaning>
+			<kun>つい・づ</kun>
+			<on>ジョ</on>
+			<kun>じょ・す</kun>
+		</kanji>
+		<kanji>
+			<char>徐</char>
+			<meaning>Slowly; Gradually; Gently</meaning>
+			<kun>おもむろ・に</kun>
+			<on>ジョ</on>
+		</kanji>
+		<kanji>
+			<char>償</char>
+			<meaning>Redeem; Reparation; Restitution</meaning>
+			<kun>つぐな・う</kun>
+			<on>ショウ</on>
+			<kun>つぐな・い</kun>
+		</kanji>
+		<kanji>
+			<char>匠</char>
+			<meaning>Craftsman; Artisan; Workman</meaning>
+			<kun>たくみ</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>升</char>
+			<meaning>Measure; Unit of volume</meaning>
+			<kun>ます</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>召</char>
+			<meaning>Send for; Call; Summons</meaning>
+			<kun>め・し</kun>
+			<on>ショウ</on>
+			<kun>め・す</kun>
+		</kanji>
+		<kanji>
+			<char>奨</char>
+			<meaning>Recommend; Praise; Compensation</meaning>
+			<kun>すす・める</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>宵</char>
+			<meaning>Evening; Night</meaning>
+			<kun>よい</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>尚</char>
+			<meaning>Furthermore; Esteem</meaning>
+			<kun>なお</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>床</char>
+			<meaning>Bed; Floor</meaning>
+			<kun>とこ</kun>
+			<kun>ゆか・しい</kun>
+			<on>ショウ</on>
+			<kun>ゆか</kun>
+		</kanji>
+		<kanji>
+			<char>彰</char>
+			<meaning>Manifestation</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>抄</char>
+			<meaning>Quotation; Excerpt</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>掌</char>
+			<meaning>Palm of the hand; Administration</meaning>
+			<kun>たなうら</kun>
+			<kun>てのひら</kun>
+			<on>ショウ</on>
+			<kun>たなごころ</kun>
+		</kanji>
+		<kanji>
+			<char>昇</char>
+			<meaning>Ascend; Arise; Go up</meaning>
+			<kun>のぼ・る</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>晶</char>
+			<meaning>Crystal</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>沼</char>
+			<meaning>Bog; Marsh; Pond</meaning>
+			<kun>ぬま</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>渉</char>
+			<meaning>Extend; Cross water; Negotiation</meaning>
+			<kun>わた・る</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>焦</char>
+			<meaning>Burn; Irritate; Impatience</meaning>
+			<kun>こ・がれる</kun>
+			<kun>じ・らす</kun>
+			<kun>あせ・り</kun>
+			<kun>こ・がす</kun>
+			<kun>け・げる</kun>
+			<kun>じ・れる</kun>
+			<kun>あせ・る</kun>
+		</kanji>
+		<kanji>
+			<char>症</char>
+			<meaning>Affliction; Illness; Symptoms</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>硝</char>
+			<meaning>Nitrate</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>礁</char>
+			<meaning>Reef</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>祥</char>
+			<meaning>Good omen; Auspicious</meaning>
+			<on>ショウ</on>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>称</char>
+			<meaning>Give praise; Call by a name; Title</meaning>
+			<kun>たた・える</kun>
+			<kun>たた・う</kun>
+			<on>ショウ</on>
+			<kun>とな・える</kun>
+			<kun>とな・う</kun>
+		</kanji>
+		<kanji>
+			<char>粧</char>
+			<meaning>Makeup; Cosmetics</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>紹</char>
+			<meaning>Introduction</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>肖</char>
+			<meaning>Share in good luck; Semblance</meaning>
+			<kun>あやか・る</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>衝</char>
+			<meaning>Thrust; Collision</meaning>
+			<kun>つ・く</kun>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>訟</char>
+			<meaning>Litigation</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>詔</char>
+			<meaning>Edict; Decree</meaning>
+			<kun>のりごと</kun>
+			<on>ショウ</on>
+			<kun>みことのり</kun>
+		</kanji>
+		<kanji>
+			<char>詳</char>
+			<meaning>In detail</meaning>
+			<on>ショウ</on>
+		</kanji>
+		<kanji>
+			<char>鐘</char>
+			<meaning>Bell; Chime</meaning>
+			<on>ショウ</on>
+			<kun>かね</kun>
+		</kanji>
+		<kanji>
+			<char>丈</char>
+			<meaning>Stature; Height</meaning>
+			<kun>たき</kun>
+			<kun>つえ</kun>
+			<on>ジョウ</on>
+			<kun>たけ</kun>
+		</kanji>
+		<kanji>
+			<char>冗</char>
+			<meaning>Superfluous; Redundant</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>剰</char>
+			<meaning>Excess; Surplus; Besides</meaning>
+			<kun>あまつさ・え</kun>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>壌</char>
+			<meaning>Earth; 10^28</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>嬢</char>
+			<meaning>Daughter; Young woman</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>浄</char>
+			<meaning>Purify; Cleanliness</meaning>
+			<kun>きよ・い</kun>
+			<kun>きよ・まる</kun>
+			<on>ジョウ</on>
+			<kun>きよ・める</kun>
+		</kanji>
+		<kanji>
+			<char>畳</char>
+			<meaning>Fold up; Tatami mat</meaning>
+			<kun>たたみ</kun>
+			<on>ジョウ</on>
+			<kun>たた・む</kun>
+		</kanji>
+		<kanji>
+			<char>譲</char>
+			<meaning>Assign; Hand over; Transfer</meaning>
+			<kun>ゆず・る</kun>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>醸</char>
+			<meaning>Brew; Give rise to; Cause</meaning>
+			<kun>かも・す</kun>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>錠</char>
+			<meaning>Lock; Padlock</meaning>
+			<on>ジョウ</on>
+		</kanji>
+		<kanji>
+			<char>嘱</char>
+			<meaning>Entrusting; Charging with</meaning>
+			<on>ショク</on>
+		</kanji>
+		<kanji>
+			<char>飾</char>
+			<meaning>Adorn; Ornamentation; Decoration</meaning>
+			<kun>かざ・り</kun>
+			<on>ショク</on>
+			<kun>かざ・る</kun>
+		</kanji>
+		<kanji>
+			<char>殖</char>
+			<meaning>Multiply; Increase; Reproduction</meaning>
+			<kun>ふ・える</kun>
+			<on>ショク</on>
+			<kun>ふ・やす</kun>
+		</kanji>
+		<kanji>
+			<char>触</char>
+			<meaning>Touch; Violate; Proclamation</meaning>
+			<kun>さわ・る</kun>
+			<kun>ふ・れる</kun>
+			<on>ショク</on>
+			<kun>ふ・れ</kun>
+			<kun>ふ・る</kun>
+		</kanji>
+		<kanji>
+			<char>辱</char>
+			<meaning>Put to shame; Feel shame; Disgrace</meaning>
+			<kun>はずかし・める</kun>
+			<kun>はずかし・む</kun>
+			<on>ジョク</on>
+			<kun>はずかし・め</kun>
+		</kanji>
+		<kanji>
+			<char>伸</char>
+			<meaning>Lengthen; Stretch out; Iron clothes</meaning>
+			<kun>のし</kun>
+			<kun>の・ばす</kun>
+			<on>シン</on>
+			<kun>の・す</kun>
+		</kanji>
+		<kanji>
+			<char>侵</char>
+			<meaning>Invade; Infringe; Trespass</meaning>
+			<kun>おか・す</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>唇</char>
+			<meaning>Lips</meaning>
+			<kun>くちびる</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>娠</char>
+			<meaning>Pregnancy</meaning>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>寝</char>
+			<meaning>Sleep; Put to bed</meaning>
+			<kun>ね</kun>
+			<kun>ね・かせる</kun>
+			<kun>い・ぬ</kun>
+			<kun>い</kun>
+			<on>シン</on>
+			<kun>ね・かす</kun>
+			<kun>ぬ</kun>
+			<kun>ね・る</kun>
+		</kanji>
+		<kanji>
+			<char>審</char>
+			<meaning>Court; Trial</meaning>
+			<kun>つまび・らか</kun>
+			<on>シン</on>
+			<kun>つばひ・らか</kun>
+		</kanji>
+		<kanji>
+			<char>慎</char>
+			<meaning>Be discreet; Self-control</meaning>
+			<kun>つつし・む</kun>
+			<on>シン</on>
+			<kun>つつし・み</kun>
+		</kanji>
+		<kanji>
+			<char>振</char>
+			<meaning>Shake; Swing; Wave</meaning>
+			<kun>ふ・る</kun>
+			<kun>ふ・り</kun>
+			<kun>ふり</kun>
+			<on>シン</on>
+			<kun>ぶ・り</kun>
+			<kun>ふる</kun>
+			<kun>ふ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>浸</char>
+			<meaning>Soak; Dip in; Flood</meaning>
+			<kun>つ・ける</kun>
+			<kun>ひた・し</kun>
+			<on>シン</on>
+			<kun>ひた・す</kun>
+			<kun>ひた・る</kun>
+		</kanji>
+		<kanji>
+			<char>紳</char>
+			<meaning>Gentleman</meaning>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>薪</char>
+			<meaning>Firewood; Kindling</meaning>
+			<kun>まき</kun>
+			<kun>たきぎ</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>診</char>
+			<meaning>Examine; Diagnosis</meaning>
+			<kun>み・る</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>辛</char>
+			<meaning>Spicy; Painful; Barely</meaning>
+			<kun>かのと</kun>
+			<kun>から・い</kun>
+			<kun>かろ・うじて</kun>
+			<on>シン</on>
+			<kun>から</kun>
+			<kun>つら・い</kun>
+		</kanji>
+		<kanji>
+			<char>震</char>
+			<meaning>Shake; Tremble; Earthquake</meaning>
+			<kun>ふる・い</kun>
+			<kun>ふる・える</kun>
+			<on>シン</on>
+			<kun>ふる・う</kun>
+			<kun>ふる・え</kun>
+		</kanji>
+		<kanji>
+			<char>刃</char>
+			<meaning>Sword; Blade</meaning>
+			<kun>は</kun>
+			<on>ジン</on>
+			<kun>やいば</kun>
+		</kanji>
+		<kanji>
+			<char>尋</char>
+			<meaning>Enquire; Examination</meaning>
+			<on>ジン</on>
+			<kun>たず・ねる</kun>
+			<kun>ひろ</kun>
+		</kanji>
+		<kanji>
+			<char>甚</char>
+			<meaning>Intense; Profound; Exceedingly</meaning>
+			<kun>いた・い</kun>
+			<kun>はなは・だしい</kun>
+			<on>ジン</on>
+			<kun>はなは・だ</kun>
+		</kanji>
+		<kanji>
+			<char>尽</char>
+			<meaning>Run out; Give up on; Exhaust</meaning>
+			<kun>つ・きる</kun>
+			<kun>つ・くす</kun>
+			<on>ジン</on>
+			<kun>つ・かす</kun>
+			<kun>ことごと・く</kun>
+		</kanji>
+		<kanji>
+			<char>迅</char>
+			<meaning>Swift</meaning>
+			<on>ジン</on>
+		</kanji>
+		<kanji>
+			<char>陣</char>
+			<meaning>Camp; Formation</meaning>
+			<on>ジン</on>
+		</kanji>
+		<kanji>
+			<char>酢</char>
+			<meaning>Vinegar</meaning>
+			<on>サク</on>
+			<kun>す</kun>
+		</kanji>
+		<kanji>
+			<char>吹</char>
+			<meaning>Blow; Smoke</meaning>
+			<kun>ふ・く</kun>
+			<kun>ふ・かす</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>帥</char>
+			<meaning>Teacher; Expert;Commander; leading troops; governor</meaning>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>炊</char>
+			<meaning>Cook food; Boil</meaning>
+			<kun>た・く</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>睡</char>
+			<meaning>Sleeping</meaning>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>粋</char>
+			<meaning>Style; Refinement; Elegance</meaning>
+			<kun>いき</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>衰</char>
+			<meaning>Decay; Decline; Collapse</meaning>
+			<kun>おとろ・える</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>遂</char>
+			<meaning>Accomplish; Finally</meaning>
+			<kun>と・げる</kun>
+			<on>スイ</on>
+			<kun>つい・に</kun>
+		</kanji>
+		<kanji>
+			<char>酔</char>
+			<meaning>Get drunk</meaning>
+			<kun>よ・う</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>錘</char>
+			<meaning>Spindle</meaning>
+			<kun>つむ</kun>
+			<on>スイ</on>
+		</kanji>
+		<kanji>
+			<char>随</char>
+			<meaning>Obey; Follow orders</meaning>
+			<kun>したが・う</kun>
+			<kun>まにま</kun>
+			<on>ズイ</on>
+			<kun>まにま・に</kun>
+		</kanji>
+		<kanji>
+			<char>髄</char>
+			<meaning>Marrow; Core</meaning>
+			<on>ズイ</on>
+		</kanji>
+		<kanji>
+			<char>崇</char>
+			<meaning>Worship; Revere</meaning>
+			<kun>あが・める</kun>
+			<on>スウ</on>
+		</kanji>
+		<kanji>
+			<char>枢</char>
+			<meaning>Pivot; Central</meaning>
+			<kun>とぼそ</kun>
+			<on>スウ</on>
+		</kanji>
+		<kanji>
+			<char>据</char>
+			<meaning>Lay something down; Squat; Sit down</meaning>
+			<kun>す・わる</kun>
+			<kun>す・える</kun>
+		</kanji>
+		<kanji>
+			<char>杉</char>
+			<meaning>Japanese cedar; Cryptomeria</meaning>
+			<kun>すぎ</kun>
+		</kanji>
+		<kanji>
+			<char>澄</char>
+			<meaning>Become clear; Put on airs</meaning>
+			<kun>す・ます</kun>
+			<on>チョウ</on>
+			<kun>す・む</kun>
+		</kanji>
+		<kanji>
+			<char>瀬</char>
+			<meaning>Rapids; Current</meaning>
+			<kun>せ</kun>
+		</kanji>
+		<kanji>
+			<char>畝</char>
+			<meaning>Ridge; Furrow; Unit of area</meaning>
+			<kun>うね</kun>
+			<kun>せ</kun>
+			<kun>う・ねる</kun>
+		</kanji>
+		<kanji>
+			<char>是</char>
+			<meaning>Justice; Right; This</meaning>
+			<kun>これ</kun>
+			<on>ゼ</on>
+		</kanji>
+		<kanji>
+			<char>姓</char>
+			<meaning>Family name</meaning>
+			<on>ショウ</on>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>征</char>
+			<meaning>Expedition; Conquest; Subjugation</meaning>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>牲</char>
+			<meaning>Sacrifice; Offering</meaning>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>誓</char>
+			<meaning>Swear; Vow; Oath</meaning>
+			<kun>ちか・う</kun>
+			<on>セイ</on>
+			<kun>ちか・い</kun>
+		</kanji>
+		<kanji>
+			<char>請</char>
+			<meaning>Request; Accept; Solicit</meaning>
+			<on>セイ</on>
+			<kun>こ・う</kun>
+			<kun>う・ける</kun>
+			<on>ショウ</on>
+			<on>シン</on>
+			<kun>こ・い</kun>
+		</kanji>
+		<kanji>
+			<char>逝</char>
+			<meaning>Pass away; Death</meaning>
+			<kun>ゆ・く</kun>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>斉</char>
+			<meaning>Symmetrical; Simultaneous</meaning>
+			<kun>ひと・しい</kun>
+			<on>セイ</on>
+		</kanji>
+		<kanji>
+			<char>隻</char>
+			<meaning>One of two; Counter for ships</meaning>
+			<on>セっ</on>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>惜</char>
+			<meaning>Be stingy; Begrudge; Regret</meaning>
+			<kun>お・しい</kun>
+			<on>セキ</on>
+			<kun>お・しむ</kun>
+		</kanji>
+		<kanji>
+			<char>斥</char>
+			<meaning>Retreat; Repel; Expulsion</meaning>
+			<kun>しりぞ・く</kun>
+			<on>セっ</on>
+			<on>セキ</on>
+			<kun>しりぞ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>析</char>
+			<meaning>Analysis</meaning>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>籍</char>
+			<meaning>Family register</meaning>
+			<on>セキ</on>
+		</kanji>
+		<kanji>
+			<char>跡</char>
+			<meaning>Tracks; Scar; Ruins</meaning>
+			<on>セキ</on>
+			<kun>あと</kun>
+		</kanji>
+		<kanji>
+			<char>拙</char>
+			<meaning>Poor quality</meaning>
+			<kun>つたな・い</kun>
+			<on>セツ</on>
+			<on>セっ</on>
+		</kanji>
+		<kanji>
+			<char>摂</char>
+			<meaning>Intake; Absorption</meaning>
+			<on>セっ</on>
+			<on>セツ</on>
+		</kanji>
+		<kanji>
+			<char>窃</char>
+			<meaning>Secretly</meaning>
+			<kun>ひそ・か</kun>
+			<on>セツ</on>
+			<on>セっ</on>
+		</kanji>
+		<kanji>
+			<char>仙</char>
+			<meaning>Hermit; Wizard</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>占</char>
+			<meaning>Predict; Foretell; Occupy</meaning>
+			<kun>うらな・う</kun>
+			<kun>し・む</kun>
+			<on>セン</on>
+			<kun>うらな・い</kun>
+			<kun>し・める</kun>
+		</kanji>
+		<kanji>
+			<char>扇</char>
+			<meaning>Fan</meaning>
+			<kun>おうぎ</kun>
+			<on>セン</on>
+			<kun>おう・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>栓</char>
+			<meaning>Plug; Stopper</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>潜</char>
+			<meaning>Dive; Pass through; Conceal</meaning>
+			<kun>ひそ・む</kun>
+			<kun>もぐ・る</kun>
+			<kun>くぐ・る</kun>
+			<on>セン</on>
+			<kun>ひそ・める</kun>
+			<kun>むぐ・る</kun>
+		</kanji>
+		<kanji>
+			<char>旋</char>
+			<meaning>Rotation</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>繊</char>
+			<meaning>Fibers</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>薦</char>
+			<meaning>Recommend; Advise; Suggest</meaning>
+			<kun>すす・める</kun>
+			<on>セン</on>
+			<kun>すす・め</kun>
+		</kanji>
+		<kanji>
+			<char>践</char>
+			<meaning>Implementation</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>遷</char>
+			<meaning>Movement; Transition</meaning>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>銑</char>
+			<meaning>Pig iron</meaning>
+			<kun>ずく</kun>
+			<on>セン</on>
+			<kun>つく</kun>
+		</kanji>
+		<kanji>
+			<char>鮮</char>
+			<meaning>Fresh; Clear; Korea</meaning>
+			<kun>あざ・やか</kun>
+			<on>セン</on>
+		</kanji>
+		<kanji>
+			<char>漸</char>
+			<meaning>Gradually; Finally</meaning>
+			<kun>ようや・く</kun>
+			<on>ゼン</on>
+		</kanji>
+		<kanji>
+			<char>禅</char>
+			<meaning>Zen Buddhism</meaning>
+			<on>ゼン</on>
+		</kanji>
+		<kanji>
+			<char>繕</char>
+			<meaning>Repair; Mend</meaning>
+			<kun>つくろ・い</kun>
+			<on>ゼン</on>
+			<kun>つくろ・う</kun>
+		</kanji>
+		<kanji>
+			<char>塑</char>
+			<meaning>Model</meaning>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>措</char>
+			<meaning>Set aside; Allocation</meaning>
+			<kun>お・く</kun>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>疎</char>
+			<meaning>Shun; Unpleasant; Sparse</meaning>
+			<kun>うと・い</kun>
+			<kun>うと・ましい</kun>
+			<kun>まば・ら</kun>
+			<kun>うと・んじる</kun>
+			<on>ソ</on>
+			<kun>おろそ・か</kun>
+			<kun>あば・ら</kun>
+			<kun>うと・む</kun>
+		</kanji>
+		<kanji>
+			<char>礎</char>
+			<meaning>Foundations; Fundamental</meaning>
+			<on>ソ</on>
+			<kun>いしずえ</kun>
+		</kanji>
+		<kanji>
+			<char>租</char>
+			<meaning>Taxation</meaning>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>粗</char>
+			<meaning>Coarse; Rough; Blemish</meaning>
+			<kun>あら・い</kun>
+			<kun>あら</kun>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>訴</char>
+			<meaning>Sue; Accusation; Complaint</meaning>
+			<kun>うった・える</kun>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>阻</char>
+			<meaning>Obstruct; Hinder</meaning>
+			<kun>はば・む</kun>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>僧</char>
+			<meaning>Priest; Monk</meaning>
+			<on>ゾウ</on>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>双</char>
+			<meaning>Pair; Twin; Double</meaning>
+			<kun>ふた</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>喪</char>
+			<meaning>Mourning; Loss</meaning>
+			<kun>も</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>壮</char>
+			<meaning>Vigour; Magnificence</meaning>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>捜</char>
+			<meaning>Search; Seek; Investigation</meaning>
+			<kun>さが・す</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>掃</char>
+			<meaning>Sweep up; Gather up; Cleaning</meaning>
+			<kun>は・く</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>挿</char>
+			<meaning>Insert; Graft</meaning>
+			<kun>さ・す</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>曹</char>
+			<meaning>Sergeant; Officer</meaning>
+			<on>ゾウ</on>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>槽</char>
+			<meaning>Cistern; Tank</meaning>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>燥</char>
+			<meaning>Dry; Dehydrated</meaning>
+			<kun>はしゃ・ぐ</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>荘</char>
+			<meaning>Villa; Manor</meaning>
+			<on>ショウ</on>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>葬</char>
+			<meaning>Bury; Funeral</meaning>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>藻</char>
+			<meaning>Algae; Seaweed</meaning>
+			<kun>も</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>遭</char>
+			<meaning>Encounter; Meet with</meaning>
+			<on>ソウ</on>
+			<kun>あ・う</kun>
+		</kanji>
+		<kanji>
+			<char>霜</char>
+			<meaning>Frost</meaning>
+			<kun>しも</kun>
+			<on>ソウ</on>
+		</kanji>
+		<kanji>
+			<char>騒</char>
+			<meaning>Annoy; Cause trouble; Uproar</meaning>
+			<kun>さわ・がす</kun>
+			<kun>さわ・ぎ</kun>
+			<on>ソウ</on>
+			<kun>さわ・がしい</kun>
+			<kun>さわ・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>憎</char>
+			<meaning>Detest; Hateful</meaning>
+			<kun>にく・い</kun>
+			<kun>にく・む</kun>
+			<on>ゾウ</on>
+			<kun>にく・しみ</kun>
+		</kanji>
+		<kanji>
+			<char>贈</char>
+			<meaning>Send; Confer; Present</meaning>
+			<on>ゾウ</on>
+			<on>ソウ</on>
+			<kun>おく・る</kun>
+		</kanji>
+		<kanji>
+			<char>促</char>
+			<meaning>Stimulate; Incite; Demand</meaning>
+			<kun>うなが・す</kun>
+			<on>ソク</on>
+		</kanji>
+		<kanji>
+			<char>即</char>
+			<meaning>Namely; Immediate; Instant</meaning>
+			<on>ソク</on>
+			<kun>すなわ・ち</kun>
+			<on>ソっ</on>
+		</kanji>
+		<kanji>
+			<char>俗</char>
+			<meaning>Custom; Vulgarity; Secular</meaning>
+			<on>ゾっ</on>
+			<on>ゾク</on>
+		</kanji>
+		<kanji>
+			<char>賊</char>
+			<meaning>Villain; Bandit</meaning>
+			<on>ゾク</on>
+		</kanji>
+		<kanji>
+			<char>堕</char>
+			<meaning>Depravity; Corruption</meaning>
+			<on>ダ</on>
+		</kanji>
+		<kanji>
+			<char>妥</char>
+			<meaning>Agreement</meaning>
+			<on>ダ</on>
+		</kanji>
+		<kanji>
+			<char>惰</char>
+			<meaning>Laziness</meaning>
+			<on>ダ</on>
+		</kanji>
+		<kanji>
+			<char>駄</char>
+			<meaning>Useless; Horseload</meaning>
+			<on>タ</on>
+			<on>ダ</on>
+		</kanji>
+		<kanji>
+			<char>耐</char>
+			<meaning>Endure; Resist</meaning>
+			<kun>た・える</kun>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>怠</char>
+			<meaning>Neglect; Be idle; Sluggish</meaning>
+			<kun>だる・い</kun>
+			<kun>おこた・る</kun>
+			<on>タイ</on>
+			<kun>なま・ける</kun>
+		</kanji>
+		<kanji>
+			<char>替</char>
+			<meaning>Exchange; Substitute; Convert</meaning>
+			<kun>か・え</kun>
+			<kun>か・わり</kun>
+			<on>タイ</on>
+			<kun>か・える</kun>
+			<kun>か・わる</kun>
+		</kanji>
+		<kanji>
+			<char>泰</char>
+			<meaning>Tranqulity; Peace; Thailand</meaning>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>滞</char>
+			<meaning>Stagnate; Procrastination</meaning>
+			<kun>とどこお・る</kun>
+			<on>タイ</on>
+			<kun>とどこお・り</kun>
+		</kanji>
+		<kanji>
+			<char>胎</char>
+			<meaning>Uterus</meaning>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>袋</char>
+			<meaning>Sack; Bag</meaning>
+			<on>タイ</on>
+			<kun>ふくろ</kun>
+		</kanji>
+		<kanji>
+			<char>逮</char>
+			<meaning>Apprehend</meaning>
+			<on>タイ</on>
+		</kanji>
+		<kanji>
+			<char>滝</char>
+			<meaning>Waterfall</meaning>
+			<kun>たき</kun>
+		</kanji>
+		<kanji>
+			<char>卓</char>
+			<meaning>Table; Desk</meaning>
+			<on>ショク</on>
+			<on>タク</on>
+		</kanji>
+		<kanji>
+			<char>択</char>
+			<meaning>Choose; Select</meaning>
+			<kun>えら・ぶ</kun>
+			<on>タク</on>
+		</kanji>
+		<kanji>
+			<char>拓</char>
+			<meaning>Development</meaning>
+			<on>タク</on>
+		</kanji>
+		<kanji>
+			<char>沢</char>
+			<meaning>Marsh</meaning>
+			<kun>さわ</kun>
+			<on>タク</on>
+		</kanji>
+		<kanji>
+			<char>濯</char>
+			<meaning>Rinse; Wash</meaning>
+			<kun>すす・ぐ</kun>
+			<kun>いす・ぐ</kun>
+			<on>タク</on>
+			<kun>そそ・ぐ</kun>
+			<kun>ゆす・ぐ</kun>
+		</kanji>
+		<kanji>
+			<char>託</char>
+			<meaning>Grumble; Pretend that; Entrust</meaning>
+			<kun>たく・す</kun>
+			<kun>かこ・つける</kun>
+			<on>タク</on>
+			<kun>かこ・つ</kun>
+			<kun>ことづ・け</kun>
+		</kanji>
+		<kanji>
+			<char>濁</char>
+			<meaning>Make muddy; Murky; Voiced sound</meaning>
+			<kun>にご・る</kun>
+			<kun>にご・り</kun>
+			<on>ダク</on>
+			<kun>にご・す</kun>
+		</kanji>
+		<kanji>
+			<char>諾</char>
+			<meaning>Consent; Agreement</meaning>
+			<on>ダク</on>
+		</kanji>
+		<kanji>
+			<char>但</char>
+			<meaning>However</meaning>
+			<kun>ただ・し</kun>
+		</kanji>
+		<kanji>
+			<char>奪</char>
+			<meaning>Snatch; Plunder</meaning>
+			<kun>うば・う</kun>
+			<on>ダツ</on>
+			<on>ダっ</on>
+		</kanji>
+		<kanji>
+			<char>脱</char>
+			<meaning>Take off; Remove; Shed</meaning>
+			<kun>ぬ・ぐ</kun>
+			<kun>だ・する</kun>
+			<on>ダツ</on>
+			<kun>ぬ・げる</kun>
+			<on>ダっ</on>
+		</kanji>
+		<kanji>
+			<char>棚</char>
+			<meaning>Shelf</meaning>
+			<kun>たな</kun>
+		</kanji>
+		<kanji>
+			<char>丹</char>
+			<meaning>Cinnabar</meaning>
+			<kun>に</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>嘆</char>
+			<meaning>Lament; Grieve</meaning>
+			<kun>なげ・く</kun>
+			<kun>なげ・かわしい</kun>
+			<on>タン</on>
+			<kun>なげ・き</kun>
+		</kanji>
+		<kanji>
+			<char>淡</char>
+			<meaning>Pale; Disinterested; Indifferent</meaning>
+			<kun>あわ・い</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>端</char>
+			<meaning>Origin; Edge; Terminal</meaning>
+			<kun>つま</kun>
+			<kun>はし</kun>
+			<kun>へち</kun>
+			<kun>へた</kun>
+			<kun>はた</kun>
+			<on>タン</on>
+			<kun>は</kun>
+			<kun>はな</kun>
+			<kun>はじ</kun>
+		</kanji>
+		<kanji>
+			<char>胆</char>
+			<meaning>Gall; Bile</meaning>
+			<kun>い</kun>
+			<on>タン</on>
+			<kun>きも</kun>
+		</kanji>
+		<kanji>
+			<char>鍛</char>
+			<meaning>Forge; Temper metal</meaning>
+			<kun>きた・える</kun>
+			<on>タン</on>
+		</kanji>
+		<kanji>
+			<char>壇</char>
+			<meaning>Platform; Terrace</meaning>
+			<on>ダン</on>
+		</kanji>
+		<kanji>
+			<char>弾</char>
+			<meaning>Flip; Play an instrument; Munitions</meaning>
+			<kun>ひ・く</kun>
+			<kun>はじ・ける</kun>
+			<kun>はず・み</kun>
+			<on>ダン</on>
+			<kun>はじ・く</kun>
+			<kun>はず・む</kun>
+		</kanji>
+		<kanji>
+			<char>恥</char>
+			<meaning>Feel shame; Feel shy; Disgraceful</meaning>
+			<on>チ</on>
+			<kun>は・じる</kun>
+			<kun>は・ずかしい</kun>
+			<kun>はじ</kun>
+			<kun>は・じらい</kun>
+			<kun>は・じらう</kun>
+		</kanji>
+		<kanji>
+			<char>痴</char>
+			<meaning>Become foolish; Idiotic</meaning>
+			<kun>おこ</kun>
+			<on>チ</on>
+			<kun>し・れる</kun>
+		</kanji>
+		<kanji>
+			<char>稚</char>
+			<meaning>Immature; Childish</meaning>
+			<on>チ</on>
+		</kanji>
+		<kanji>
+			<char>致</char>
+			<meaning>Do; Carry out</meaning>
+			<kun>いた・す</kun>
+			<on>チ</on>
+		</kanji>
+		<kanji>
+			<char>遅</char>
+			<meaning>Be late; Delay; Slow</meaning>
+			<kun>おそ・い</kun>
+			<kun>おく・らせる</kun>
+			<kun>おく・れ</kun>
+			<on>チ</on>
+			<kun>おく・らす</kun>
+			<kun>おく・れる</kun>
+		</kanji>
+		<kanji>
+			<char>畜</char>
+			<meaning>Livestock; Cattle; Beast</meaning>
+			<on>チク</on>
+		</kanji>
+		<kanji>
+			<char>蓄</char>
+			<meaning>Store; Accumulate; Savings</meaning>
+			<kun>たくわ・える</kun>
+			<on>チク</on>
+		</kanji>
+		<kanji>
+			<char>逐</char>
+			<meaning>One by one; Expulsion</meaning>
+			<on>チク</on>
+		</kanji>
+		<kanji>
+			<char>秩</char>
+			<meaning>Discipline; Order</meaning>
+			<on>チツ</on>
+		</kanji>
+		<kanji>
+			<char>窒</char>
+			<meaning>Suffocation; Nitrogen</meaning>
+			<on>チっ</on>
+			<on>チツ</on>
+		</kanji>
+		<kanji>
+			<char>嫡</char>
+			<meaning>Legitimate relation</meaning>
+			<on>チャク</on>
+			<on>テキ</on>
+		</kanji>
+		<kanji>
+			<char>抽</char>
+			<meaning>Pull out; Extract</meaning>
+			<kun>ひ・く</kun>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>衷</char>
+			<meaning>Inner self</meaning>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>鋳</char>
+			<meaning>Mint coin; Cast; Mould</meaning>
+			<kun>い・る</kun>
+			<on>チュウ</on>
+			<kun>い</kun>
+		</kanji>
+		<kanji>
+			<char>駐</char>
+			<meaning>Residence; Stationing</meaning>
+			<on>チュウ</on>
+		</kanji>
+		<kanji>
+			<char>弔</char>
+			<meaning>Mourn for; Hold a funeral; Burial</meaning>
+			<kun>とむら・い</kun>
+			<kun>ともら・い</kun>
+			<kun>とぶら・う</kun>
+			<on>チョウ</on>
+			<kun>とぶら・い</kun>
+			<kun>とむら・う</kun>
+		</kanji>
+		<kanji>
+			<char>彫</char>
+			<meaning>Engrave; Carve; Sculpt</meaning>
+			<kun>ほ・る</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>徴</char>
+			<meaning>Symbol; Feature; Levying</meaning>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>懲</char>
+			<meaning>Chastise; Learn one's lesson; Reprimand</meaning>
+			<kun>こ・らしめる</kun>
+			<on>チョウ</on>
+			<kun>こ・らす</kun>
+			<kun>こ・らしめ</kun>
+			<kun>こ・りる</kun>
+		</kanji>
+		<kanji>
+			<char>挑</char>
+			<meaning>Challenge; Defiance</meaning>
+			<kun>いど・む</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>眺</char>
+			<meaning>Gaze at; Scene; View</meaning>
+			<kun>なが・め</kun>
+			<on>チョウ</on>
+			<kun>なが・める</kun>
+		</kanji>
+		<kanji>
+			<char>聴</char>
+			<meaning>Listen; Be audible; Hearing</meaning>
+			<kun>き・く</kun>
+			<on>チョウ</on>
+			<kun>き・こえる</kun>
+		</kanji>
+		<kanji>
+			<char>脹</char>
+			<meaning>Swell up; Bulge</meaning>
+			<kun>ふく・れる</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>超</char>
+			<meaning>Exceed; Cross over; Hyper</meaning>
+			<kun>こ・す</kun>
+			<on>チョウ</on>
+			<kun>こ・える</kun>
+		</kanji>
+		<kanji>
+			<char>跳</char>
+			<meaning>Jump; Leap</meaning>
+			<kun>は・ね</kun>
+			<on>チョウ</on>
+			<kun>は・ねる</kun>
+			<kun>と・ぶ</kun>
+		</kanji>
+		<kanji>
+			<char>勅</char>
+			<meaning>Imperial decree</meaning>
+			<kun>みことのり</kun>
+			<on>チョク</on>
+		</kanji>
+		<kanji>
+			<char>朕</char>
+			<meaning>Imperial we</meaning>
+			<on>チン</on>
+		</kanji>
+		<kanji>
+			<char>沈</char>
+			<meaning>Sink; Submerge; Feel down</meaning>
+			<kun>しず・む</kun>
+			<on>チン</on>
+			<kun>しず・める</kun>
+		</kanji>
+		<kanji>
+			<char>珍</char>
+			<meaning>Unusual; Peculiar; Curious</meaning>
+			<kun>めずら・しい</kun>
+			<on>チン</on>
+		</kanji>
+		<kanji>
+			<char>鎮</char>
+			<meaning>Suppress; Abate; Repose</meaning>
+			<kun>しず・める</kun>
+			<on>チン</on>
+			<kun>しず・まる</kun>
+		</kanji>
+		<kanji>
+			<char>陳</char>
+			<meaning>Statement; Exhibit</meaning>
+			<on>チン</on>
+		</kanji>
+		<kanji>
+			<char>津</char>
+			<meaning>Harbour; Port</meaning>
+			<kun>つ</kun>
+			<on>シン</on>
+		</kanji>
+		<kanji>
+			<char>墜</char>
+			<meaning>Falling down</meaning>
+			<on>ツイ</on>
+		</kanji>
+		<kanji>
+			<char>塚</char>
+			<meaning>Mound</meaning>
+			<kun>つか</kun>
+		</kanji>
+		<kanji>
+			<char>漬</char>
+			<meaning>Soak; Pickle</meaning>
+			<kun>つ・かる</kun>
+			<kun>つ・ける</kun>
+			<on>シ</on>
+		</kanji>
+		<kanji>
+			<char>坪</char>
+			<meaning>Floor space; Unit of area</meaning>
+			<kun>つぼ</kun>
+		</kanji>
+		<kanji>
+			<char>釣</char>
+			<meaning>Catch fish; Fishing</meaning>
+			<kun>つ・り</kun>
+			<kun>つ・る</kun>
+			<on>チョウ</on>
+		</kanji>
+		<kanji>
+			<char>亭</char>
+			<meaning>Inn; Restaurant</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>偵</char>
+			<meaning>Spy; Detective</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>貞</char>
+			<meaning>Chastity; Fidelity</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>呈</char>
+			<meaning>Presentation; Dedication</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>堤</char>
+			<meaning>Embankment; Dike</meaning>
+			<kun>つつみ</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>帝</char>
+			<meaning>Emperor</meaning>
+			<kun>みかど</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>廷</char>
+			<meaning>Court</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>抵</char>
+			<meaning>Resistance</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>締</char>
+			<meaning>Fasten; Conclude</meaning>
+			<kun>し・まる</kun>
+			<kun>し・める</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>艇</char>
+			<meaning>Boat; Craft</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>訂</char>
+			<meaning>Edition; Revision</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>逓</char>
+			<meaning>Relaying; Successive</meaning>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>邸</char>
+			<meaning>Villa; Mansion; Residence</meaning>
+			<kun>やしき</kun>
+			<on>テイ</on>
+		</kanji>
+		<kanji>
+			<char>泥</char>
+			<meaning>Mud</meaning>
+			<kun>どろ</kun>
+			<on>デイ</on>
+		</kanji>
+		<kanji>
+			<char>摘</char>
+			<meaning>Pluck; Pinch; Trim</meaning>
+			<on>テキ</on>
+			<kun>つ・まみ</kun>
+			<kun>つま・み</kun>
+			<kun>つ・まむ</kun>
+			<kun>つ・む</kun>
+			<kun>つま・む</kun>
+		</kanji>
+		<kanji>
+			<char>滴</char>
+			<meaning>Drip; Trickle; Water drop</meaning>
+			<kun>したた・る</kun>
+			<on>テキ</on>
+			<kun>したた・り</kun>
+		</kanji>
+		<kanji>
+			<char>哲</char>
+			<meaning>Sage; Philosopher</meaning>
+			<on>テツ</on>
+		</kanji>
+		<kanji>
+			<char>徹</char>
+			<meaning>Stand vigil; Piercing</meaning>
+			<kun>て・する</kun>
+			<on>テツ</on>
+			<on>テっ</on>
+		</kanji>
+		<kanji>
+			<char>撤</char>
+			<meaning>Withdrawal</meaning>
+			<on>テツ</on>
+			<on>テっ</on>
+		</kanji>
+		<kanji>
+			<char>迭</char>
+			<meaning>Alternation</meaning>
+			<on>テツ</on>
+		</kanji>
+		<kanji>
+			<char>添</char>
+			<meaning>Accompany; Attach; Addition</meaning>
+			<kun>そ・える</kun>
+			<kun>そ・う</kun>
+			<on>テン</on>
+		</kanji>
+		<kanji>
+			<char>殿</char>
+			<meaning>Mr.; Sir; Rear guard</meaning>
+			<on>デン</on>
+			<kun>どの</kun>
+			<on>テン</on>
+			<kun>との</kun>
+			<kun>しんがり</kun>
+		</kanji>
+		<kanji>
+			<char>吐</char>
+			<meaning>Tell a lie; Spit out; Vomit</meaning>
+			<kun>つ・く</kun>
+			<kun>は・く</kun>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>塗</char>
+			<meaning>Smear with; Lacquer; Paint</meaning>
+			<kun>ぬ・る</kun>
+			<kun>ぬり</kun>
+			<kun>まぶ・す</kun>
+			<kun>まみ・れる</kun>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>斗</char>
+			<meaning>Dipper; Unit of Volume</meaning>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>渡</char>
+			<meaning>Cross over; Deliver</meaning>
+			<kun>わた・す</kun>
+			<on>ト</on>
+			<kun>わた・る</kun>
+		</kanji>
+		<kanji>
+			<char>途</char>
+			<meaning>Way; Course; Route</meaning>
+			<on>ト</on>
+		</kanji>
+		<kanji>
+			<char>奴</char>
+			<meaning>Fellow; Chap; Servant</meaning>
+			<kun>やつ</kun>
+			<kun>しゃつ</kun>
+			<kun>やつこ</kun>
+			<on>ド</on>
+			<kun>やっこ</kun>
+			<kun>め</kun>
+		</kanji>
+		<kanji>
+			<char>怒</char>
+			<meaning>Become angry; Offend; Rage</meaning>
+			<kun>いか・らす</kun>
+			<kun>いか・り</kun>
+			<on>ヌ</on>
+			<on>ド</on>
+			<kun>いか・らせる</kun>
+			<kun>いか・る</kun>
+		</kanji>
+		<kanji>
+			<char>倒</char>
+			<meaning>Fall unconscious; Knock down; Go bankrupt</meaning>
+			<kun>こ・ける</kun>
+			<kun>たお・る</kun>
+			<kun>たお・れる</kun>
+			<on>トウ</on>
+			<kun>たお・す</kun>
+			<kun>たお・れ</kun>
+		</kanji>
+		<kanji>
+			<char>凍</char>
+			<meaning>Freeze; Chill; Congeal</meaning>
+			<kun>こご・える</kun>
+			<kun>し・みる</kun>
+			<on>トウ</on>
+			<kun>い・てる</kun>
+			<kun>こお・る</kun>
+		</kanji>
+		<kanji>
+			<char>唐</char>
+			<meaning>Tang dynasty</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>塔</char>
+			<meaning>Tower; Pagoda</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>悼</char>
+			<meaning>Mourn; Lament; Memorial</meaning>
+			<kun>いた・む</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>搭</char>
+			<meaning>Embarkation; Loading</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>桃</char>
+			<meaning>Peach</meaning>
+			<kun>もも</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>棟</char>
+			<meaning>Building; Roof ridge</meaning>
+			<kun>むね</kun>
+			<on>トウ</on>
+			<kun>むな</kun>
+		</kanji>
+		<kanji>
+			<char>盗</char>
+			<meaning>Steal; Thief</meaning>
+			<kun>ぬす・む</kun>
+			<kun>ぬす</kun>
+			<on>トウ</on>
+			<kun>ぬす・み</kun>
+		</kanji>
+		<kanji>
+			<char>痘</char>
+			<meaning>Pox</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>筒</char>
+			<meaning>Tube; Pipe; Cylinder</meaning>
+			<kun>つつ</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>到</char>
+			<meaning>Arrive; Attain</meaning>
+			<kun>いた・る</kun>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>謄</char>
+			<meaning>Transcribe; Copy</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>踏</char>
+			<meaning>Step; Tread; Trample</meaning>
+			<kun>ふ・む</kun>
+			<kun>ふみ</kun>
+			<on>トウ</on>
+			<kun>ふ・まえる</kun>
+		</kanji>
+		<kanji>
+			<char>逃</char>
+			<meaning>Flee; Escape; Get away</meaning>
+			<kun>に・がす</kun>
+			<kun>のが・す</kun>
+			<kun>に・げる</kun>
+			<kun>に・げ</kun>
+			<kun>のが・れる</kun>
+		</kanji>
+		<kanji>
+			<char>透</char>
+			<meaning>Be transparent; Show through; Chink</meaning>
+			<kun>す・かす</kun>
+			<kun>す・く</kun>
+			<kun>す・ける</kun>
+			<on>トウ</on>
+			<kun>す・かし</kun>
+			<kun>す・き</kun>
+		</kanji>
+		<kanji>
+			<char>陶</char>
+			<meaning>Pottery</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>騰</char>
+			<meaning>Increasing; Jump; Hike</meaning>
+			<on>トウ</on>
+		</kanji>
+		<kanji>
+			<char>闘</char>
+			<meaning>Fight; Struggle; Combat</meaning>
+			<kun>たたか・う</kun>
+			<on>トウ</on>
+			<kun>たたか・い</kun>
+		</kanji>
+		<kanji>
+			<char>洞</char>
+			<meaning>Cave; Grotto</meaning>
+			<kun>ほら</kun>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>胴</char>
+			<meaning>Torso; Trunk; Girth</meaning>
+			<on>ドウ</on>
+		</kanji>
+		<kanji>
+			<char>峠</char>
+			<meaning>Mountain pass; Ridge</meaning>
+			<kun>とうげ</kun>
+		</kanji>
+		<kanji>
+			<char>匿</char>
+			<meaning>Conceal; Shelter</meaning>
+			<kun>かくま・う</kun>
+			<on>トク</on>
+		</kanji>
+		<kanji>
+			<char>督</char>
+			<meaning>Commander; Supervisor</meaning>
+			<on>トク</on>
+		</kanji>
+		<kanji>
+			<char>篤</char>
+			<meaning>Cordial; Serious</meaning>
+			<kun>あつ・い</kun>
+			<on>トク</on>
+			<on>トっ</on>
+		</kanji>
+		<kanji>
+			<char>凸</char>
+			<meaning>Convex</meaning>
+			<on>トっ</on>
+			<on>トツ</on>
+			<kun>でこ</kun>
+		</kanji>
+		<kanji>
+			<char>突</char>
+			<meaning>Thrust; Poke; Collision</meaning>
+			<kun>つ・く</kun>
+			<on>トっ</on>
+			<on>トツ</on>
+			<kun>つつ・く</kun>
+		</kanji>
+		<kanji>
+			<char>屯</char>
+			<meaning>Station; Post; Ton</meaning>
+			<kun>たむら</kun>
+			<kun>たむろ</kun>
+			<on>トン</on>
+		</kanji>
+		<kanji>
+			<char>豚</char>
+			<meaning>Pig</meaning>
+			<on>トン</on>
+			<kun>ぶた</kun>
+		</kanji>
+		<kanji>
+			<char>曇</char>
+			<meaning>Become cloudy; Overcast</meaning>
+			<kun>くも・り</kun>
+			<kun>くもり</kun>
+			<kun>くも・る</kun>
+		</kanji>
+		<kanji>
+			<char>鈍</char>
+			<meaning>Become dull; Blunt; Stupidity</meaning>
+			<kun>にぶ・い</kun>
+			<kun>なま・る</kun>
+			<kun>のろ</kun>
+			<on>ドン</on>
+			<kun>のろ・い</kun>
+			<kun>にぶ・る</kun>
+		</kanji>
+		<kanji>
+			<char>縄</char>
+			<meaning>Rope</meaning>
+			<on>ジョウ</on>
+			<kun>なわ</kun>
+		</kanji>
+		<kanji>
+			<char>軟</char>
+			<meaning>Soft; Limp; Gentle</meaning>
+			<kun>やわ・らか</kun>
+			<on>ナン</on>
+			<kun>やわらか・い</kun>
+		</kanji>
+		<kanji>
+			<char>尼</char>
+			<meaning>Nun; Priestess</meaning>
+			<kun>あま</kun>
+			<on>ニ</on>
+		</kanji>
+		<kanji>
+			<char>弐</char>
+			<meaning>Double; Two</meaning>
+			<kun>ふた・つ</kun>
+			<on>ニ</on>
+			<kun>ふた</kun>
+		</kanji>
+		<kanji>
+			<char>如</char>
+			<meaning>The like; As if</meaning>
+			<on>ジョ</on>
+			<kun>ごと・く</kun>
+			<on>ニョ</on>
+			<kun>ごと・き</kun>
+			<kun>ごと・し</kun>
+		</kanji>
+		<kanji>
+			<char>尿</char>
+			<meaning>Urine</meaning>
+			<on>ニョウ</on>
+		</kanji>
+		<kanji>
+			<char>妊</char>
+			<meaning>Become pregnant; Conception</meaning>
+			<kun>はら・む</kun>
+			<on>ニン</on>
+		</kanji>
+		<kanji>
+			<char>忍</char>
+			<meaning>Endure; Conceal oneself</meaning>
+			<kun>しの・ぶ</kun>
+			<on>ニン</on>
+			<kun>しの・び</kun>
+		</kanji>
+		<kanji>
+			<char>寧</char>
+			<meaning>Courtesy; Rather</meaning>
+			<kun>むし・ろ</kun>
+			<on>ネイ</on>
+		</kanji>
+		<kanji>
+			<char>猫</char>
+			<meaning>Cat</meaning>
+			<on>ビョウ</on>
+			<kun>ねこ</kun>
+		</kanji>
+		<kanji>
+			<char>粘</char>
+			<meaning>Stick to; Adhesive; Viscous</meaning>
+			<kun>ねば・り</kun>
+			<on>ネン</on>
+			<kun>ねば</kun>
+			<kun>ねば・る</kun>
+		</kanji>
+		<kanji>
+			<char>悩</char>
+			<meaning>Worry; Torment; Seductive</meaning>
+			<kun>なや・ます</kun>
+			<kun>なや・み</kun>
+			<on>ノウ</on>
+			<kun>なや・ましい</kun>
+			<kun>なや・む</kun>
+		</kanji>
+		<kanji>
+			<char>濃</char>
+			<meaning>Thick; Dense; Dark</meaning>
+			<on>ノウ</on>
+			<kun>こ・い</kun>
+		</kanji>
+		<kanji>
+			<char>把</char>
+			<meaning>Grasping; Counter for bundles</meaning>
+			<on>ワ</on>
+			<on>ハ</on>
+		</kanji>
+		<kanji>
+			<char>覇</char>
+			<meaning>Supremacy; Hegemony</meaning>
+			<on>パ</on>
+			<on>ハ</on>
+		</kanji>
+		<kanji>
+			<char>婆</char>
+			<meaning>Old woman; Grandmother</meaning>
+			<kun>ばば</kun>
+			<on>バ</on>
+			<kun>ばあ</kun>
+		</kanji>
+		<kanji>
+			<char>廃</char>
+			<meaning>Become obsolete; Rubbish; Waste</meaning>
+			<on>パイ</on>
+			<on>ハイ</on>
+		</kanji>
+		<kanji>
+			<char>排</char>
+			<meaning>Expulsion; Removal</meaning>
+			<on>バイ</on>
+			<on>パイ</on>
+			<on>ハイ</on>
+		</kanji>
+		<kanji>
+			<char>杯</char>
+			<meaning>Wine cup; Cup</meaning>
+			<on>ハイ</on>
+			<kun>つき</kun>
+			<on>パイ</on>
+			<kun>さかずき</kun>
+			<kun>はた</kun>
+		</kanji>
+		<kanji>
+			<char>輩</char>
+			<meaning>Fellow; People</meaning>
+			<on>パイ</on>
+			<kun>ばら</kun>
+			<on>ハイ</on>
+			<kun>ともがら</kun>
+			<kun>やから</kun>
+		</kanji>
+		<kanji>
+			<char>培</char>
+			<meaning>Cultivate; Develop; Culture</meaning>
+			<kun>つちか・う</kun>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>媒</char>
+			<meaning>Medium; Solvent</meaning>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>賠</char>
+			<meaning>Compensation; Reparations</meaning>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>陪</char>
+			<meaning>Attend a superior</meaning>
+			<on>バイ</on>
+		</kanji>
+		<kanji>
+			<char>伯</char>
+			<meaning>Count; Earl; Uncle</meaning>
+			<on>ハク</on>
+		</kanji>
+		<kanji>
+			<char>拍</char>
+			<meaning>Tempo; Beat</meaning>
+			<on>ハク</on>
+			<on>ヒョウ</on>
+			<on>パク</on>
+			<on>ビョウ</on>
+		</kanji>
+		<kanji>
+			<char>泊</char>
+			<meaning>Give shelter; Lodge; Berth</meaning>
+			<on>パク</on>
+			<kun>と・まる</kun>
+			<on>ハク</on>
+			<kun>と・める</kun>
+		</kanji>
+		<kanji>
+			<char>舶</char>
+			<meaning>Ocean liner</meaning>
+			<on>パク</on>
+			<on>ハク</on>
+		</kanji>
+		<kanji>
+			<char>薄</char>
+			<meaning>Become weak; Watery; Japanese pampras grass</meaning>
+			<on>ハク</on>
+			<kun>うす・める</kun>
+			<kun>うす・れる</kun>
+			<kun>うす</kun>
+			<kun>うす・い</kun>
+			<kun>うす・らぐ</kun>
+			<kun>うす・まる</kun>
+		</kanji>
+		<kanji>
+			<char>迫</char>
+			<meaning>Draw near; Press</meaning>
+			<on>パク</on>
+			<on>ハク</on>
+			<kun>せま・る</kun>
+		</kanji>
+		<kanji>
+			<char>漠</char>
+			<meaning>Vast; Vague</meaning>
+			<on>バク</on>
+		</kanji>
+		<kanji>
+			<char>爆</char>
+			<meaning>Burst open; Explosion</meaning>
+			<on>バク</on>
+		</kanji>
+		<kanji>
+			<char>縛</char>
+			<meaning>Tie up; Bind</meaning>
+			<kun>しば・る</kun>
+			<on>バク</on>
+		</kanji>
+		<kanji>
+			<char>肌</char>
+			<meaning>Skin</meaning>
+			<on>キ</on>
+			<kun>はだ</kun>
+		</kanji>
+		<kanji>
+			<char>鉢</char>
+			<meaning>Bowl; Pot</meaning>
+			<on>バチ</on>
+			<on>ハツ</on>
+			<on>ハチ</on>
+		</kanji>
+		<kanji>
+			<char>髪</char>
+			<meaning>Hair</meaning>
+			<kun>かみ</kun>
+			<on>ハツ</on>
+			<on>パツ</on>
+			<kun>がみ</kun>
+		</kanji>
+		<kanji>
+			<char>伐</char>
+			<meaning>Strike; Attack; Fell lumber</meaning>
+			<on>バツ</on>
+		</kanji>
+		<kanji>
+			<char>罰</char>
+			<meaning>Punishment; Penalty; Retribution</meaning>
+			<on>バっ</on>
+			<on>バツ</on>
+			<on>バチ</on>
+		</kanji>
+		<kanji>
+			<char>抜</char>
+			<meaning>Omit; Draw a sword; Come out</meaning>
+			<kun>ぬ・かる</kun>
+			<kun>ぬ・ける</kun>
+			<on>バっ</on>
+			<on>バツ</on>
+			<kun>ぬ・かす</kun>
+			<kun>ぬ・く</kun>
+		</kanji>
+		<kanji>
+			<char>閥</char>
+			<meaning>Clan; Clique; Faction</meaning>
+			<on>バツ</on>
+		</kanji>
+		<kanji>
+			<char>伴</char>
+			<meaning>Accompany; Companion</meaning>
+			<on>ハン</on>
+			<kun>とも</kun>
+			<kun>ともな・う</kun>
+			<on>バン</on>
+		</kanji>
+		<kanji>
+			<char>帆</char>
+			<meaning>Ship's sail</meaning>
+			<on>パン</on>
+			<on>ハン</on>
+			<on>ホ</on>
+		</kanji>
+		<kanji>
+			<char>搬</char>
+			<meaning>Transportation</meaning>
+			<on>パン</on>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>畔</char>
+			<meaning>Shore; Waterside</meaning>
+			<kun>あぜ</kun>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>繁</char>
+			<meaning>Prosper; Flourishing</meaning>
+			<on>パン</on>
+			<kun>しげ・る</kun>
+			<on>ハン</on>
+			<kun>しげ</kun>
+			<kun>しげ・く</kun>
+		</kanji>
+		<kanji>
+			<char>般</char>
+			<meaning>General; Sort</meaning>
+			<on>ハン</on>
+			<on>パン</on>
+		</kanji>
+		<kanji>
+			<char>藩</char>
+			<meaning>Clan</meaning>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>販</char>
+			<meaning>Sales</meaning>
+			<on>パン</on>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>範</char>
+			<meaning>Pattern; Model</meaning>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>煩</char>
+			<meaning>Worry about; Bother</meaning>
+			<kun>わずら・い</kun>
+			<kun>わずら・わす</kun>
+			<on>ハン</on>
+			<kun>うるさ・い</kun>
+			<kun>わずら・う</kun>
+			<on>ボン</on>
+			<kun>わずら・わしい</kun>
+		</kanji>
+		<kanji>
+			<char>頒</char>
+			<meaning>Apportioning</meaning>
+			<on>ハン</on>
+		</kanji>
+		<kanji>
+			<char>盤</char>
+			<meaning>Disk; Bowl; Tray</meaning>
+			<on>バン</on>
+		</kanji>
+		<kanji>
+			<char>蛮</char>
+			<meaning>Barbarian</meaning>
+			<on>バン</on>
+		</kanji>
+		<kanji>
+			<char>卑</char>
+			<meaning>Despise; Abase; Vulgar</meaning>
+			<on>ピ</on>
+			<kun>いや・しい</kun>
+			<kun>いや・しめる</kun>
+			<on>ヒ</on>
+			<on>ビ</on>
+			<kun>いや・しむ</kun>
+		</kanji>
+		<kanji>
+			<char>妃</char>
+			<meaning>Queen; Princess</meaning>
+			<kun>きさき</kun>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>彼</char>
+			<meaning>He; That</meaning>
+			<on>ヒ</on>
+			<kun>かれ</kun>
+			<kun>かの</kun>
+		</kanji>
+		<kanji>
+			<char>扉</char>
+			<meaning>Door</meaning>
+			<on>ヒ</on>
+			<kun>とびら</kun>
+		</kanji>
+		<kanji>
+			<char>披</char>
+			<meaning>Expressing; Revelation</meaning>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>泌</char>
+			<meaning>Secretion</meaning>
+			<on>ヒツ</on>
+			<on>ヒ</on>
+		</kanji>
+		<kanji>
+			<char>疲</char>
+			<meaning>Get tired; Fatigue</meaning>
+			<kun>つか・れ</kun>
+			<on>ヒ</on>
+			<kun>つか・らす</kun>
+			<kun>つか・れる</kun>
+		</kanji>
+		<kanji>
+			<char>碑</char>
+			<meaning>Monument</meaning>
+			<on>ピ</on>
+			<on>ヒ</on>
+			<kun>いしぶみ</kun>
+		</kanji>
+		<kanji>
+			<char>罷</char>
+			<meaning>Quit; Strike; Dismissal</meaning>
+			<on>ヒ</on>
+			<kun>や・める</kun>
+			<kun>まか・り</kun>
+			<kun>まか・る</kun>
+		</kanji>
+		<kanji>
+			<char>被</char>
+			<meaning>Wear; Suffer</meaning>
+			<on>ピ</on>
+			<kun>かぶ・せる</kun>
+			<kun>こうむ・る</kun>
+			<kun>こうぶ・る</kun>
+			<kun>かがふ・る</kun>
+			<on>ヒ</on>
+			<kun>おお・う</kun>
+			<kun>ほどこ・る</kun>
+			<kun>かむ・る</kun>
+			<kun>かぶ・る</kun>
+		</kanji>
+		<kanji>
+			<char>避</char>
+			<meaning>Avoid; Evade; Take shelter</meaning>
+			<kun>さ・く</kun>
+			<on>ヒ</on>
+			<kun>さ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>尾</char>
+			<meaning>Tail; End</meaning>
+			<on>ビ</on>
+			<kun>お</kun>
+		</kanji>
+		<kanji>
+			<char>微</char>
+			<meaning>Faint; Dim; Slight</meaning>
+			<kun>かす・か</kun>
+			<on>ビ</on>
+		</kanji>
+		<kanji>
+			<char>匹</char>
+			<meaning>Counter for animals and rolls of cloth</meaning>
+			<on>ピキ</on>
+			<on>ヒっ</on>
+			<on>ヒキ</on>
+			<on>ヒツ</on>
+		</kanji>
+		<kanji>
+			<char>姫</char>
+			<meaning>Princess</meaning>
+			<on>キ</on>
+			<kun>ひめ</kun>
+		</kanji>
+		<kanji>
+			<char>漂</char>
+			<meaning>Float; Drift; Roam</meaning>
+			<kun>ただよ・う</kun>
+			<on>ヒョウ</on>
+		</kanji>
+		<kanji>
+			<char>描</char>
+			<meaning>Draw; Paint; Depict</meaning>
+			<kun>か・く</kun>
+			<on>ビョウ</on>
+			<kun>えが・く</kun>
+		</kanji>
+		<kanji>
+			<char>苗</char>
+			<meaning>Seedling</meaning>
+			<kun>なえ</kun>
+			<on>ビョウ</on>
+			<kun>なわ</kun>
+		</kanji>
+		<kanji>
+			<char>浜</char>
+			<meaning>Beach; Seashore</meaning>
+			<kun>はま</kun>
+			<on>ヒン</on>
+		</kanji>
+		<kanji>
+			<char>賓</char>
+			<meaning>Visitor; Guest</meaning>
+			<on>ヒン</on>
+		</kanji>
+		<kanji>
+			<char>頻</char>
+			<meaning>Frequently; Repeatedly</meaning>
+			<kun>しき・る</kun>
+			<on>ヒン</on>
+			<kun>しき・りに</kun>
+		</kanji>
+		<kanji>
+			<char>敏</char>
+			<meaning>Nimble; Keen; Fast-witted</meaning>
+			<on>ビン</on>
+		</kanji>
+		<kanji>
+			<char>瓶</char>
+			<meaning>Bottle; Vase; Earthenware pot</meaning>
+			<kun>かめ</kun>
+			<on>ビン</on>
+		</kanji>
+		<kanji>
+			<char>怖</char>
+			<meaning>Fear; Dread</meaning>
+			<kun>こわ</kun>
+			<kun>こわ・がる</kun>
+			<kun>お・ず</kun>
+			<on>フ</on>
+			<kun>こわ・い</kun>
+			<kun>お・そる</kun>
+			<kun>お・じる</kun>
+		</kanji>
+		<kanji>
+			<char>扶</char>
+			<meaning>Help; Aid; Allowance</meaning>
+			<kun>たす・ける</kun>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>敷</char>
+			<meaning>Pave; Spread over</meaning>
+			<kun>し・く</kun>
+			<on>フ</on>
+			<kun>しき</kun>
+		</kanji>
+		<kanji>
+			<char>普</char>
+			<meaning>Widely; Generally</meaning>
+			<kun>あまね・く</kun>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>浮</char>
+			<meaning>Float; Make merry</meaning>
+			<kun>う・かべる</kun>
+			<kun>う・く</kun>
+			<on>フ</on>
+			<kun>う・かぶ</kun>
+			<kun>う・かれる</kun>
+			<kun>うき</kun>
+			<kun>う・き</kun>
+		</kanji>
+		<kanji>
+			<char>符</char>
+			<meaning>Symbol; Token</meaning>
+			<on>フ</on>
+			<on>プ</on>
+		</kanji>
+		<kanji>
+			<char>腐</char>
+			<meaning>Rot; Decay; Corrosion</meaning>
+			<kun>くさ・す</kun>
+			<kun>くさ・る</kun>
+			<on>フ</on>
+			<kun>くさ・らす</kun>
+			<kun>くさ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>膚</char>
+			<meaning>Skin</meaning>
+			<kun>はだ</kun>
+			<on>フ</on>
+			<kun>はだえ</kun>
+		</kanji>
+		<kanji>
+			<char>譜</char>
+			<meaning>Record; Program; Musical score</meaning>
+			<on>プ</on>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>賦</char>
+			<meaning>Allotment; Installment; Levy</meaning>
+			<on>フ</on>
+			<on>プ</on>
+		</kanji>
+		<kanji>
+			<char>赴</char>
+			<meaning>Take up a post; Proceed to</meaning>
+			<kun>おもむ・く</kun>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>附</char>
+			<meaning>Attached to; Associated</meaning>
+			<on>プ</on>
+			<on>フ</on>
+		</kanji>
+		<kanji>
+			<char>侮</char>
+			<meaning>Despise; Disdain; Contempt</meaning>
+			<kun>あなど・る</kun>
+			<kun>あなず・る</kun>
+			<on>ブ</on>
+			<kun>あなど・り</kun>
+		</kanji>
+		<kanji>
+			<char>舞</char>
+			<meaning>Dance</meaning>
+			<kun>まい</kun>
+			<kun>ま・う</kun>
+			<on>ブ</on>
+			<kun>ま・い</kun>
+		</kanji>
+		<kanji>
+			<char>封</char>
+			<meaning>Confine; Close off; Seal</meaning>
+			<on>ホウ</on>
+			<kun>ふう・じる</kun>
+			<on>プウ</on>
+			<on>フウ</on>
+		</kanji>
+		<kanji>
+			<char>伏</char>
+			<meaning>Bend down; Prostrate oneself; Turn over</meaning>
+			<on>プク</on>
+			<kun>ふ・せる</kun>
+			<on>フク</on>
+			<kun>ふ・す</kun>
+		</kanji>
+		<kanji>
+			<char>幅</char>
+			<meaning>Width; Scroll</meaning>
+			<on>プク</on>
+			<on>フク</on>
+			<kun>はば</kun>
+		</kanji>
+		<kanji>
+			<char>覆</char>
+			<meaning>Cover over; Overturn; Topple</meaning>
+			<on>プク</on>
+			<kun>おお・い</kun>
+			<on>フク</on>
+			<kun>おお・う</kun>
+			<kun>くつがえ・る</kun>
+		</kanji>
+		<kanji>
+			<char>払</char>
+			<meaning>Pay; Clear away</meaning>
+			<kun>はら・う</kun>
+			<on>フっ</on>
+			<kun>はらい</kun>
+			<on>フク</on>
+		</kanji>
+		<kanji>
+			<char>沸</char>
+			<meaning>Boil; Simmer</meaning>
+			<kun>わ・かす</kun>
+			<on>フツ</on>
+			<kun>わ・く</kun>
+		</kanji>
+		<kanji>
+			<char>噴</char>
+			<meaning>Emit; Erupt</meaning>
+			<on>フン</on>
+			<kun>ふ・く</kun>
+		</kanji>
+		<kanji>
+			<char>墳</char>
+			<meaning>Burial mound; Tomb</meaning>
+			<on>フン</on>
+		</kanji>
+		<kanji>
+			<char>憤</char>
+			<meaning>Be indignant; Be angry</meaning>
+			<on>プン</on>
+			<on>フン</on>
+			<kun>いきどお・る</kun>
+		</kanji>
+		<kanji>
+			<char>紛</char>
+			<meaning>Flour; Powder</meaning>
+			<kun>こ</kun>
+			<on>フン</on>
+			<kun>こな</kun>
+		</kanji>
+		<kanji>
+			<char>雰</char>
+			<meaning>Atmosphere</meaning>
+			<on>フン</on>
+		</kanji>
+		<kanji>
+			<char>丙</char>
+			<meaning>Third</meaning>
+			<kun>ひのえ</kun>
+			<on>ヘイ</on>
+		</kanji>
+		<kanji>
+			<char>併</char>
+			<meaning>Get together; Unite; Combination</meaning>
+			<on>ペイ</on>
+			<kun>あわ・せる</kun>
+			<kun>しか・も</kun>
+			<on>ヘイ</on>
+			<kun>あわ・さる</kun>
+			<kun>しか・し</kun>
+		</kanji>
+		<kanji>
+			<char>塀</char>
+			<meaning>Wall; Fence</meaning>
+			<on>ベイ</on>
+			<on>ヘイ</on>
+		</kanji>
+		<kanji>
+			<char>幣</char>
+			<meaning>Currency</meaning>
+			<kun>ぬさ</kun>
+			<on>ヘイ</on>
+		</kanji>
+		<kanji>
+			<char>弊</char>
+			<meaning>Corrupt; Vice; Evil</meaning>
+			<on>ヘイ</on>
+		</kanji>
+		<kanji>
+			<char>柄</char>
+			<meaning>Hilt; Handle; Pattern</meaning>
+			<kun>がら</kun>
+			<kun>つか</kun>
+			<on>ヘイ</on>
+			<kun>え</kun>
+		</kanji>
+		<kanji>
+			<char>壁</char>
+			<meaning>Wall</meaning>
+			<kun>かべ</kun>
+			<on>ヘキ</on>
+		</kanji>
+		<kanji>
+			<char>癖</char>
+			<meaning>Bad habit; Vice; Addiction</meaning>
+			<kun>くせ</kun>
+			<on>ヘキ</on>
+			<on>ペキ</on>
+		</kanji>
+		<kanji>
+			<char>偏</char>
+			<meaning>Be partial; Inclination; Left-side radical</meaning>
+			<kun>ひとえ</kun>
+			<kun>かたよ・り</kun>
+			<on>ヘン</on>
+			<kun>かたよ・る</kun>
+		</kanji>
+		<kanji>
+			<char>遍</char>
+			<meaning>One time; Universal; Far and wide</meaning>
+			<on>ベン</on>
+			<kun>あまね・く</kun>
+			<on>ペン</on>
+			<on>ヘン</on>
+		</kanji>
+		<kanji>
+			<char>舗</char>
+			<meaning>Shop; Store</meaning>
+			<on>ポ</on>
+			<on>ホ</on>
+		</kanji>
+		<kanji>
+			<char>捕</char>
+			<meaning>Capture; Seize; Arrest</meaning>
+			<kun>と・らえる</kun>
+			<kun>つか・まえる</kun>
+			<kun>と・る</kun>
+			<on>ホ</on>
+			<kun>つか・まる</kun>
+			<kun>と・らわれる</kun>
+		</kanji>
+		<kanji>
+			<char>穂</char>
+			<meaning>Ear of grain; Head of plant</meaning>
+			<on>スイ</on>
+			<kun>ほ</kun>
+		</kanji>
+		<kanji>
+			<char>募</char>
+			<meaning>Solicit help; Recruitment; Fund-raising</meaning>
+			<kun>つの・る</kun>
+			<on>ボ</on>
+		</kanji>
+		<kanji>
+			<char>慕</char>
+			<meaning>Yearn for; Adoration; Affection</meaning>
+			<kun>した・う</kun>
+			<on>ボ</on>
+		</kanji>
+		<kanji>
+			<char>簿</char>
+			<meaning>Ledger; Directory; Register</meaning>
+			<on>ボ</on>
+		</kanji>
+		<kanji>
+			<char>倣</char>
+			<meaning>Imitate; Emulate; Copy</meaning>
+			<kun>なら・う</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>俸</char>
+			<meaning>Salary; Allowance</meaning>
+			<on>ポウ</on>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>奉</char>
+			<meaning>Obey; Serve; Revere</meaning>
+			<on>ポウ</on>
+			<kun>ほう・じる</kun>
+			<on>ボウ</on>
+			<kun>たてまつ・る</kun>
+			<on>ブ</on>
+			<on>ホウ</on>
+			<kun>まつ・る</kun>
+			<kun>ほう・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>峰</char>
+			<meaning>Peak; Summit; Back of a sword</meaning>
+			<kun>みね</kun>
+			<on>ホウ</on>
+			<on>ポウ</on>
+		</kanji>
+		<kanji>
+			<char>崩</char>
+			<meaning>Collapse; Destroy; Pull down</meaning>
+			<kun>くず・れる</kun>
+			<kun>くず・す</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>抱</char>
+			<meaning>Hold in arms; Hug; Embrace</meaning>
+			<on>ボウ</on>
+			<kun>だ・く</kun>
+			<on>ホウ</on>
+			<kun>かか・える</kun>
+			<kun>いだ・く</kun>
+		</kanji>
+		<kanji>
+			<char>泡</char>
+			<meaning>Bubbles; Foam</meaning>
+			<on>ホウ</on>
+			<kun>あわ</kun>
+			<on>ポウ</on>
+		</kanji>
+		<kanji>
+			<char>砲</char>
+			<meaning>Gun; Artillery</meaning>
+			<on>ポウ</on>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>縫</char>
+			<meaning>Sew; Embroider</meaning>
+			<kun>ぬ・い</kun>
+			<kun>ぬい</kun>
+			<on>ホウ</on>
+			<kun>ぬ・う</kun>
+		</kanji>
+		<kanji>
+			<char>胞</char>
+			<meaning>Sac; Cell</meaning>
+			<on>ボウ</on>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>芳</char>
+			<meaning>Fragrance; Perfume; Favourable</meaning>
+			<kun>かんば・しい</kun>
+			<on>ホウ</on>
+			<kun>かお・り</kun>
+		</kanji>
+		<kanji>
+			<char>褒</char>
+			<meaning>Praise; Admire; Compliment</meaning>
+			<kun>ほ・める</kun>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>邦</char>
+			<meaning>Country; State; Nation</meaning>
+			<kun>くに</kun>
+			<on>ホウ</on>
+			<on>ポウ</on>
+		</kanji>
+		<kanji>
+			<char>飽</char>
+			<meaning>Tire of; Lose interest; Satiated</meaning>
+			<kun>あ・き</kun>
+			<kun>あ・く</kun>
+			<kun>あ・かす</kun>
+			<kun>あ・きる</kun>
+		</kanji>
+		<kanji>
+			<char>乏</char>
+			<meaning>Scarce; Lacking</meaning>
+			<kun>とぼ・しい</kun>
+			<on>ボウ</on>
+			<kun>とも・しい</kun>
+		</kanji>
+		<kanji>
+			<char>傍</char>
+			<meaning>Onlooker; Bystander; To one side</meaning>
+			<kun>はた</kun>
+			<kun>そば</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>剖</char>
+			<meaning>Division; Dissection</meaning>
+			<on>ボウ</on>
+			<on>ホウ</on>
+		</kanji>
+		<kanji>
+			<char>坊</char>
+			<meaning>Person; Son; Monk</meaning>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>妨</char>
+			<meaning>Disturb; Obstruct; Interfere</meaning>
+			<kun>さまた・げる</kun>
+			<kun>さまた・げ</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>帽</char>
+			<meaning>Hat; Cap; Headgear</meaning>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>忙</char>
+			<meaning>Busy; Restless</meaning>
+			<kun>いそが・しい</kun>
+			<kun>せわ・しげ</kun>
+			<on>ボウ</on>
+			<kun>せわ・しい</kun>
+		</kanji>
+		<kanji>
+			<char>房</char>
+			<meaning>Tuft; Room</meaning>
+			<kun>ふさ</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>某</char>
+			<meaning>Someone; A certain</meaning>
+			<kun>なにがし</kun>
+			<kun>それがし</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>冒</char>
+			<meaning>Run a risk; Desecrate</meaning>
+			<kun>おか・す</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>紡</char>
+			<meaning>Spin thread</meaning>
+			<kun>つむ・ぐ</kun>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>肪</char>
+			<meaning>Fat</meaning>
+			<on>ボウ</on>
+		</kanji>
+		<kanji>
+			<char>膨</char>
+			<meaning>Swell; Puff up; Inflation</meaning>
+			<kun>ふく・らみ</kun>
+			<on>ボウ</on>
+			<kun>ふく・らむ</kun>
+			<kun>ふく・れる</kun>
+			<kun>ふく・らます</kun>
+		</kanji>
+		<kanji>
+			<char>謀</char>
+			<meaning>Cheat; Plot; Scheme</meaning>
+			<kun>はか・る</kun>
+			<on>ボウ</on>
+			<kun>たばか・る</kun>
+		</kanji>
+		<kanji>
+			<char>僕</char>
+			<meaning>Manservant; Male pronoun</meaning>
+			<kun>しもべ</kun>
+			<on>ボク</on>
+		</kanji>
+		<kanji>
+			<char>墨</char>
+			<meaning>India ink</meaning>
+			<kun>すみ</kun>
+			<on>ボク</on>
+			<on>ボっ</on>
+		</kanji>
+		<kanji>
+			<char>撲</char>
+			<meaning>Hit; Strike</meaning>
+			<on>ボク</on>
+			<on>モウ</on>
+		</kanji>
+		<kanji>
+			<char>朴</char>
+			<meaning>Simple; Naive</meaning>
+			<kun>ほお</kun>
+			<on>ボク</on>
+		</kanji>
+		<kanji>
+			<char>没</char>
+			<meaning>Subsidence; Submergence; Death</meaning>
+			<on>ボっ</on>
+			<on>ボツ</on>
+		</kanji>
+		<kanji>
+			<char>堀</char>
+			<meaning>Moat; Pond; Canal</meaning>
+			<kun>ほ・る</kun>
+			<kun>ほり</kun>
+		</kanji>
+		<kanji>
+			<char>奔</char>
+			<meaning>Rush; Bustle</meaning>
+			<on>ポン</on>
+			<on>ホン</on>
+		</kanji>
+		<kanji>
+			<char>翻</char>
+			<meaning>Flutter; Change mind; Adapt</meaning>
+			<kun>ひるがえ・す</kun>
+			<kun>ひるがえ・る</kun>
+			<on>ホン</on>
+		</kanji>
+		<kanji>
+			<char>凡</char>
+			<meaning>Mediocre; Every; Approximately</meaning>
+			<on>ボン</on>
+			<kun>すべ・て</kun>
+			<on>ハン</on>
+			<kun>およ・そ</kun>
+			<kun>あら・ゆる</kun>
+		</kanji>
+		<kanji>
+			<char>盆</char>
+			<meaning>Name of festival; Tray</meaning>
+			<on>ボン</on>
+		</kanji>
+		<kanji>
+			<char>摩</char>
+			<meaning>Rub; Scrape; Stroke</meaning>
+			<kun>さす・る</kun>
+			<kun>す・れる</kun>
+			<on>マ</on>
+			<kun>す・る</kun>
+		</kanji>
+		<kanji>
+			<char>磨</char>
+			<meaning>Grind; Polish; Scour</meaning>
+			<kun>みが・く</kun>
+			<kun>す・る</kun>
+			<on>マ</on>
+			<kun>と・ぐ</kun>
+			<kun>す・れる</kun>
+		</kanji>
+		<kanji>
+			<char>魔</char>
+			<meaning>Demon; Evil; Magic</meaning>
+			<on>マ</on>
+		</kanji>
+		<kanji>
+			<char>麻</char>
+			<meaning>Flax; Hemp; Linen</meaning>
+			<kun>あさ</kun>
+			<on>オ</on>
+			<on>マ</on>
+			<on>ソ</on>
+		</kanji>
+		<kanji>
+			<char>埋</char>
+			<meaning>Bury; Fill up; Cover over</meaning>
+			<kun>うず・まる</kun>
+			<kun>うず・める</kun>
+			<kun>う・もれる</kun>
+			<kun>う・まる</kun>
+			<kun>う・める</kun>
+			<kun>い・ける</kun>
+			<on>マイ</on>
+		</kanji>
+		<kanji>
+			<char>膜</char>
+			<meaning>Membrane</meaning>
+			<on>マク</on>
+		</kanji>
+		<kanji>
+			<char>又</char>
+			<meaning>Again; Also</meaning>
+			<kun>また</kun>
+		</kanji>
+		<kanji>
+			<char>抹</char>
+			<meaning>Wiping; Daubing</meaning>
+			<on>マっ</on>
+			<on>マツ</on>
+		</kanji>
+		<kanji>
+			<char>繭</char>
+			<meaning>Cocoon</meaning>
+			<on>ケン</on>
+			<kun>まゆ</kun>
+		</kanji>
+		<kanji>
+			<char>慢</char>
+			<meaning>Arrogance; Laziness</meaning>
+			<on>マン</on>
+		</kanji>
+		<kanji>
+			<char>漫</char>
+			<meaning>Aimless; Rambling</meaning>
+			<kun>そぞ・ろ</kun>
+			<on>マン</on>
+		</kanji>
+		<kanji>
+			<char>魅</char>
+			<meaning>Bewitch; Enchant; Fascinate</meaning>
+			<kun>ばか・す</kun>
+			<on>ミ</on>
+			<kun>ばけ・る</kun>
+		</kanji>
+		<kanji>
+			<char>岬</char>
+			<meaning>Cape; Headland</meaning>
+			<kun>みさき</kun>
+			<on>コウ</on>
+		</kanji>
+		<kanji>
+			<char>妙</char>
+			<meaning>Strange; Curious; Peculiar</meaning>
+			<on>ミョウ</on>
+		</kanji>
+		<kanji>
+			<char>眠</char>
+			<meaning>Sleep</meaning>
+			<kun>ねむ・い</kun>
+			<kun>ねむ・り</kun>
+			<kun>ねぶ・たい</kun>
+			<on>ミン</on>
+			<kun>ねむ・たい</kun>
+			<kun>ねぶ・る</kun>
+			<kun>ねむ・る</kun>
+		</kanji>
+		<kanji>
+			<char>矛</char>
+			<meaning>Halberd; Arms</meaning>
+			<on>ム</on>
+			<kun>ほこ</kun>
+		</kanji>
+		<kanji>
+			<char>霧</char>
+			<meaning>Mist; Fog</meaning>
+			<kun>きり</kun>
+			<on>ム</on>
+		</kanji>
+		<kanji>
+			<char>婿</char>
+			<meaning>Son-in-law; Bridegroom</meaning>
+			<on>セイ</on>
+			<kun>むこ</kun>
+		</kanji>
+		<kanji>
+			<char>娘</char>
+			<meaning>Daughter; Girl</meaning>
+			<on>ジョウ</on>
+			<kun>むすめ</kun>
+			<kun>こ</kun>
+		</kanji>
+		<kanji>
+			<char>銘</char>
+			<meaning>Inscription; Motto; Signature</meaning>
+			<on>メイ</on>
+		</kanji>
+		<kanji>
+			<char>滅</char>
+			<meaning>Perish; Destroy; Annihiliation</meaning>
+			<kun>ほろ・びる</kun>
+			<on>メツ</on>
+			<kun>ほろ・ぼす</kun>
+		</kanji>
+		<kanji>
+			<char>免</char>
+			<meaning>Escape from; Exemption; Dismissal</meaning>
+			<kun>めん・じる</kun>
+			<kun>まぬか・れる</kun>
+			<on>メン</on>
+			<kun>めん・ずる</kun>
+		</kanji>
+		<kanji>
+			<char>茂</char>
+			<meaning>Grow thickly; Thicket; Luxuriant foliage</meaning>
+			<kun>しげ・み</kun>
+			<on>モ</on>
+			<kun>しげ・る</kun>
+		</kanji>
+		<kanji>
+			<char>妄</char>
+			<meaning>Delusion; Credulity; Recklessly</meaning>
+			<on>ボウ</on>
+			<on>モウ</on>
+			<kun>みだ・り</kun>
+		</kanji>
+		<kanji>
+			<char>猛</char>
+			<meaning>Fierce; Ferocious; Brave</meaning>
+			<kun>たけ・し</kun>
+			<on>モウ</on>
+		</kanji>
+		<kanji>
+			<char>盲</char>
+			<meaning>Blind; Blind man</meaning>
+			<kun>めくら</kun>
+			<on>モウ</on>
+			<kun>めしい</kun>
+		</kanji>
+		<kanji>
+			<char>網</char>
+			<meaning>Net; Network</meaning>
+			<kun>あみ</kun>
+			<on>モウ</on>
+		</kanji>
+		<kanji>
+			<char>耗</char>
+			<meaning>Consumption; Decrease</meaning>
+			<on>コウ</on>
+			<on>モウ</on>
+		</kanji>
+		<kanji>
+			<char>黙</char>
+			<meaning>Be silent; Mute</meaning>
+			<kun>だんま・り</kun>
+			<kun>もく・す</kun>
+			<on>モク</on>
+			<kun>だま・る</kun>
+			<kun>もだ・す</kun>
+		</kanji>
+		<kanji>
+			<char>戻</char>
+			<meaning>Restore; Put back; Bring back</meaning>
+			<kun>もど・す</kun>
+			<kun>もど・り</kun>
+			<on>レイ</on>
+			<kun>もど・る</kun>
+		</kanji>
+		<kanji>
+			<char>紋</char>
+			<meaning>Emblem; Crest; Design</meaning>
+			<on>モン</on>
+		</kanji>
+		<kanji>
+			<char>匁</char>
+			<meaning>Unit of weight</meaning>
+			<kun>もんめ</kun>
+		</kanji>
+		<kanji>
+			<char>厄</char>
+			<meaning>Misfortune; Evil; Disaster</meaning>
+			<on>ヤっ</on>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>躍</char>
+			<meaning>Dance; Jump</meaning>
+			<kun>おど・る</kun>
+			<on>ヤク</on>
+		</kanji>
+		<kanji>
+			<char>柳</char>
+			<meaning>Willow</meaning>
+			<kun>やなぎ</kun>
+			<on>リュウ</on>
+		</kanji>
+		<kanji>
+			<char>愉</char>
+			<meaning>Hapiness; Pleasant</meaning>
+			<on>ユ</on>
+		</kanji>
+		<kanji>
+			<char>癒</char>
+			<meaning>Heal; Recover; Quench thirst</meaning>
+			<kun>い・える</kun>
+			<on>ユ</on>
+			<kun>いや・す</kun>
+		</kanji>
+		<kanji>
+			<char>諭</char>
+			<meaning>Admonish; Reason with; Remonstrate</meaning>
+			<kun>さと・す</kun>
+			<on>ユ</on>
+		</kanji>
+		<kanji>
+			<char>唯</char>
+			<meaning>Only; Sole; Free of charge</meaning>
+			<on>ユイ</on>
+			<kun>ただ</kun>
+		</kanji>
+		<kanji>
+			<char>幽</char>
+			<meaning>Dim; Faint; Secluded</meaning>
+			<kun>かす・か</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>悠</char>
+			<meaning>Quiet; Calm; Composed</meaning>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>憂</char>
+			<meaning>Grieve; Lament; Sorrow</meaning>
+			<kun>う・い</kun>
+			<kun>うれ・える</kun>
+			<on>ユウ</on>
+			<kun>う・れい</kun>
+		</kanji>
+		<kanji>
+			<char>猶</char>
+			<meaning>Yet; Still</meaning>
+			<kun>なお</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>裕</char>
+			<meaning>Abundance</meaning>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>誘</char>
+			<meaning>Invite; Induce; Solicit</meaning>
+			<kun>さそ・う</kun>
+			<on>ユウ</on>
+			<kun>さそ・い</kun>
+		</kanji>
+		<kanji>
+			<char>雄</char>
+			<meaning>Hero; Masculine; Male animal</meaning>
+			<kun>おす</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>融</char>
+			<meaning>Melt; Dissolve; Finance</meaning>
+			<kun>と・ける</kun>
+			<on>ユウ</on>
+		</kanji>
+		<kanji>
+			<char>与</char>
+			<meaning>Award to; Confer upon; Participate</meaning>
+			<kun>あた・える</kun>
+			<kun>あずか・る</kun>
+			<on>ヨ</on>
+			<kun>あた・え</kun>
+			<kun>むた</kun>
+		</kanji>
+		<kanji>
+			<char>誉</char>
+			<meaning>Praise; Honour; Compliment</meaning>
+			<kun>ほめ・る</kun>
+			<on>ヨ</on>
+			<kun>ほま・れ</kun>
+		</kanji>
+		<kanji>
+			<char>庸</char>
+			<meaning>Ordinary; Commonplace; Moderate</meaning>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>揚</char>
+			<meaning>Rise; Deep fry; Generous</meaning>
+			<kun>あ・がる</kun>
+			<kun>あ・げ</kun>
+			<on>ヨウ</on>
+			<kun>あ・げる</kun>
+			<kun>あげ</kun>
+		</kanji>
+		<kanji>
+			<char>揺</char>
+			<meaning>Shake; Rock; Tremble</meaning>
+			<kun>ゆ・す</kun>
+			<kun>ゆ・り</kun>
+			<kun>ゆ・れ</kun>
+			<kun>ゆ・る</kun>
+			<kun>ゆ・する</kun>
+			<kun>ゆ・すぶる</kun>
+			<kun>ゆり</kun>
+			<kun>ゆ・さぶる</kun>
+			<kun>ゆ・るがす</kun>
+			<kun>ゆ・らす</kun>
+			<on>ヨウ</on>
+			<kun>ゆ・るぐ</kun>
+			<kun>ゆ・れる</kun>
+			<kun>ゆ・らぐ</kun>
+		</kanji>
+		<kanji>
+			<char>擁</char>
+			<meaning>Possess; Support; Protect</meaning>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>溶</char>
+			<meaning>Dissolve; Soluble</meaning>
+			<kun>と・く</kun>
+			<kun>と・ける</kun>
+			<on>ヨウ</on>
+			<kun>と・かす</kun>
+		</kanji>
+		<kanji>
+			<char>窯</char>
+			<meaning>Kettle; Furnace; Kiln</meaning>
+			<kun>かま</kun>
+			<on>ヨウ</on>
+		</kanji>
+		<kanji>
+			<char>謡</char>
+			<meaning>Sing; Recite Noh; Ballad</meaning>
+			<on>ヨウ</on>
+			<kun>うたい</kun>
+			<kun>うた・う</kun>
+		</kanji>
+		<kanji>
+			<char>踊</char>
+			<meaning>Dance</meaning>
+			<kun>おど・る</kun>
+			<on>ヨウ</on>
+			<kun>おど・り</kun>
+		</kanji>
+		<kanji>
+			<char>抑</char>
+			<meaning>Suppress; Curb; In the first place</meaning>
+			<kun>そもそも</kun>
+			<kun>そも</kun>
+			<on>ヨク</on>
+			<kun>おさ・える</kun>
+		</kanji>
+		<kanji>
+			<char>翼</char>
+			<meaning>Wings</meaning>
+			<kun>つばさ</kun>
+			<on>ヨク</on>
+		</kanji>
+		<kanji>
+			<char>羅</char>
+			<meaning>Silk fabric; Capture; Lining up</meaning>
+			<on>ラ</on>
+		</kanji>
+		<kanji>
+			<char>裸</char>
+			<meaning>Naked; Undressed</meaning>
+			<kun>はだか</kun>
+			<on>ラ</on>
+		</kanji>
+		<kanji>
+			<char>頼</char>
+			<meaning>Request; Rely upon</meaning>
+			<kun>たの・む</kun>
+			<kun>たよ・る</kun>
+			<on>ライ</on>
+			<kun>たの・み</kun>
+			<kun>たよ・り</kun>
+		</kanji>
+		<kanji>
+			<char>雷</char>
+			<meaning>Thunder; Lightning</meaning>
+			<kun>かみなり</kun>
+			<on>ライ</on>
+		</kanji>
+		<kanji>
+			<char>絡</char>
+			<meaning>Bind; Entwine; Link</meaning>
+			<kun>から・まる</kun>
+			<kun>から・む</kun>
+			<on>ラク</on>
+			<kun>から・み</kun>
+			<kun>から・める</kun>
+		</kanji>
+		<kanji>
+			<char>酪</char>
+			<meaning>Dairy produce</meaning>
+			<on>ラク</on>
+		</kanji>
+		<kanji>
+			<char>欄</char>
+			<meaning>Column of text</meaning>
+			<on>ラン</on>
+		</kanji>
+		<kanji>
+			<char>濫</char>
+			<meaning>Indiscriminate; Slovenly</meaning>
+			<kun>みだ・り</kun>
+			<kun>みだ・りがわしい</kun>
+			<on>ラン</on>
+			<kun>みだ・りがましい</kun>
+		</kanji>
+		<kanji>
+			<char>吏</char>
+			<meaning>Public official</meaning>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>履</char>
+			<meaning>Clogs; Footwear</meaning>
+			<kun>は・く</kun>
+			<on>リ</on>
+			<kun>はき</kun>
+		</kanji>
+		<kanji>
+			<char>痢</char>
+			<meaning>Diarrhoea</meaning>
+			<on>リ</on>
+		</kanji>
+		<kanji>
+			<char>離</char>
+			<meaning>Part; Separate</meaning>
+			<kun>はな・す</kun>
+			<on>リ</on>
+			<kun>はな・れる</kun>
+		</kanji>
+		<kanji>
+			<char>硫</char>
+			<meaning>Sulphur</meaning>
+			<on>イ</on>
+			<on>リュウ</on>
+		</kanji>
+		<kanji>
+			<char>粒</char>
+			<meaning>Grain; Particle; Drop</meaning>
+			<on>リュウ</on>
+			<kun>つぶ</kun>
+		</kanji>
+		<kanji>
+			<char>隆</char>
+			<meaning>Prosperity</meaning>
+			<on>リュウ</on>
+		</kanji>
+		<kanji>
+			<char>竜</char>
+			<meaning>Dragon</meaning>
+			<kun>たつ</kun>
+			<on>リュウ</on>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>慮</char>
+			<meaning>Consider; Restraint; Reserve</meaning>
+			<kun>おもんぱか・る</kun>
+			<on>リョ</on>
+		</kanji>
+		<kanji>
+			<char>虜</char>
+			<meaning>Prisoner</meaning>
+			<on>リョ</on>
+		</kanji>
+		<kanji>
+			<char>了</char>
+			<meaning>Completion; Termination</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>僚</char>
+			<meaning>Official; Staff member</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>寮</char>
+			<meaning>Dormitory; Hostel</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>涼</char>
+			<meaning>Cool off; Refreshing</meaning>
+			<kun>すず・しい</kun>
+			<kun>すず</kun>
+			<on>リョウ</on>
+			<kun>すず・む</kun>
+		</kanji>
+		<kanji>
+			<char>猟</char>
+			<meaning>Hunting</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>療</char>
+			<meaning>Treatment</meaning>
+			<on>リョウ</on>
+		</kanji>
+		<kanji>
+			<char>糧</char>
+			<meaning>Sustenance; Provisions</meaning>
+			<on>ロウ</on>
+			<on>リョウ</on>
+			<kun>かて</kun>
+		</kanji>
+		<kanji>
+			<char>陵</char>
+			<meaning>Land; Continent</meaning>
+			<on>ロク</on>
+			<on>リク</on>
+		</kanji>
+		<kanji>
+			<char>倫</char>
+			<meaning>Morals</meaning>
+			<on>リン</on>
+		</kanji>
+		<kanji>
+			<char>厘</char>
+			<meaning>Unit of currency; Very small amount</meaning>
+			<on>リン</on>
+		</kanji>
+		<kanji>
+			<char>隣</char>
+			<meaning>Neigbour; Adjacent</meaning>
+			<kun>となり</kun>
+			<on>リン</on>
+		</kanji>
+		<kanji>
+			<char>塁</char>
+			<meaning>Base; Fort</meaning>
+			<kun>とりで</kun>
+			<on>ルイ</on>
+		</kanji>
+		<kanji>
+			<char>涙</char>
+			<meaning>Tears</meaning>
+			<kun>なみだ</kun>
+			<on>ルイ</on>
+		</kanji>
+		<kanji>
+			<char>累</char>
+			<meaning>Heap; Accumulation</meaning>
+			<on>ルイ</on>
+		</kanji>
+		<kanji>
+			<char>励</char>
+			<meaning>Endeavour; Work diligently; Incentive</meaning>
+			<kun>はげ・む</kun>
+			<kun>はげ・ます</kun>
+			<on>レイ</on>
+			<kun>はげ・み</kun>
+		</kanji>
+		<kanji>
+			<char>鈴</char>
+			<meaning>Bell; Chime</meaning>
+			<kun>すず</kun>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>隷</char>
+			<meaning>Slave; Subordinate</meaning>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>零</char>
+			<meaning>Zero; Spill; Overflow</meaning>
+			<kun>こぼ・す</kun>
+			<on>レイ</on>
+			<kun>こぼ・れる</kun>
+		</kanji>
+		<kanji>
+			<char>霊</char>
+			<meaning>Spirit; Soul</meaning>
+			<on>リョウ</on>
+			<on>レイ</on>
+			<kun>たま</kun>
+		</kanji>
+		<kanji>
+			<char>麗</char>
+			<meaning>Splendid; Beautiful; Lovely</meaning>
+			<kun>うるわ・しい</kun>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>齢</char>
+			<meaning>Age</meaning>
+			<kun>よわい</kun>
+			<on>レイ</on>
+		</kanji>
+		<kanji>
+			<char>暦</char>
+			<meaning>Era; Calendar; Almanac</meaning>
+			<kun>こよみ</kun>
+			<on>レキ</on>
+		</kanji>
+		<kanji>
+			<char>劣</char>
+			<meaning>Fall behind; Be worse than; Inferior</meaning>
+			<kun>おと・る</kun>
+			<on>レツ</on>
+		</kanji>
+		<kanji>
+			<char>烈</char>
+			<meaning>Severe; Intense; Extreme</meaning>
+			<kun>はげ・しい</kun>
+			<on>レツ</on>
+		</kanji>
+		<kanji>
+			<char>裂</char>
+			<meaning>Split; Tear; Rupture</meaning>
+			<kun>さ・く</kun>
+			<on>レツ</on>
+			<kun>さ・ける</kun>
+		</kanji>
+		<kanji>
+			<char>廉</char>
+			<meaning>Scrupulous; Honest; Cheap</meaning>
+			<kun>かど</kun>
+			<on>レン</on>
+		</kanji>
+		<kanji>
+			<char>恋</char>
+			<meaning>Love; Beloved</meaning>
+			<kun>こい</kun>
+			<kun>こい・しい</kun>
+			<on>レン</on>
+			<kun>こ・う</kun>
+		</kanji>
+		<kanji>
+			<char>錬</char>
+			<meaning>Train; Practice; Forge</meaning>
+			<on>レン</on>
+		</kanji>
+		<kanji>
+			<char>炉</char>
+			<meaning>Hearth; Fireplace; Furnace</meaning>
+			<on>ロ</on>
+		</kanji>
+		<kanji>
+			<char>露</char>
+			<meaning>Dew; Exposure</meaning>
+			<on>ロ</on>
+			<kun>つゆ</kun>
+			<kun>あらわ</kun>
+		</kanji>
+		<kanji>
+			<char>廊</char>
+			<meaning>Corridor; Gallery; Passage</meaning>
+			<on>ロウ</on>
+		</kanji>
+		<kanji>
+			<char>楼</char>
+			<meaning>Watchtower; Tall building</meaning>
+			<on>ロウ</on>
+		</kanji>
+		<kanji>
+			<char>浪</char>
+			<meaning>Wanderer; Nomad; Vagrant</meaning>
+			<on>ロウ</on>
+		</kanji>
+		<kanji>
+			<char>漏</char>
+			<meaning>Leak; Omit</meaning>
+			<kun>も・る</kun>
+			<kun>も・れる</kun>
+			<on>ロウ</on>
+			<kun>も・らす</kun>
+			<kun>も・れ</kun>
+		</kanji>
+		<kanji>
+			<char>郎</char>
+			<meaning>Son; Fellow</meaning>
+			<on>ロウ</on>
+		</kanji>
+		<kanji>
+			<char>賄</char>
+			<meaning>Give board; Bribery</meaning>
+			<on>ワイ</on>
+			<kun>まかな・う</kun>
+			<kun>まかな・い</kun>
+		</kanji>
+		<kanji>
+			<char>惑</char>
+			<meaning>Perplex; Fascinate; Bewilder</meaning>
+			<kun>まど・う</kun>
+			<kun>まど・わせる</kun>
+			<on>ワク</on>
+			<kun>まど・わす</kun>
+		</kanji>
+		<kanji>
+			<char>枠</char>
+			<meaning>Frame; Border; Reel</meaning>
+			<on>ワク</on>
+		</kanji>
+		<kanji>
+			<char>湾</char>
+			<meaning>Gulf; Bay; Inlet</meaning>
+			<on>ワン</on>
+		</kanji>
+		<kanji>
+			<char>腕</char>
+			<meaning>Arm; Ability</meaning>
+			<kun>うで</kun>
+			<on>ワン</on>
+		</kanji>
+	</category>
+</characters>


### PR DESCRIPTION
This commit introduces Kanji input functionality to the application. It replaces the `wanakana` library with `jsNihonIME`, a self-contained library that handles Romaji to Kana conversion and provides Kanji suggestions from a local XML file.

The following changes were made:
- Added `jsNihonIME.js` and `kanji.xml` to the project.
- Replaced `wanakana.min.js` with `jsNihonIME.js` in `index.html`.
- Modified `js/script.js` to use the new library for Romaji to Kana conversion.
- Added a dropdown list to display Kanji suggestions as the user types.
- Implemented a function to get Kanji suggestions from the `jsNihonIME` library.
- Optimized the `kanji` function in `jsNihonIME.js` to cache the XML data and improve performance.