### PR TITLE
fix: Address errors caused by jsNihonIME library

### DIFF
--- a/js/jsNihonIME.js
+++ b/js/jsNihonIME.js
@@ -197,7 +197,10 @@ function kanji(lvl)
 	}
 
 	// Draws the buttons inside the div
-	document.getElementById("divbuttons").innerHTML = Buttons_tmp;
+	const divButtons = document.getElementById("divbuttons");
+	if (divButtons) {
+		divButtons.innerHTML = Buttons_tmp;
+	}
 	return result;
 }
 
@@ -309,7 +312,9 @@ function katakana()
 function replacekana()
 {
 	// Temporary variable, for efficiency
-	str = document.getElementById("k_textarea").value;
+	const answerInput = document.getElementById("answer-input");
+	if (!answerInput) return;
+	str = answerInput.value;
 
 
 	/*---HIRAGANA; KATAKANA;---*/
@@ -609,5 +614,8 @@ function replacekana()
 
 
 	// Puts the temporary variable inside of the textbox
-	document.getElementById("k_textarea").value = str;
+	const answerInput = document.getElementById("answer-input");
+	if (answerInput) {
+		answerInput.value = str;
+	}
 }


### PR DESCRIPTION
This commit fixes errors that were occurring after integrating the jsNihonIME library. The errors were caused by the library trying to access DOM elements that did not exist in the application's HTML structure.

The following changes were made:
- Added checks in `jsNihonIME.js` to ensure that the `divbuttons` and `k_textarea` elements exist before trying to manipulate them.
- Updated the `replacekana` function to use the correct element ID (`answer-input`) for the input field.