### PR TITLE
Fix: Address 'Identifier has already been declared' error

### DIFF
--- a/js/jsNihonIME.js
+++ b/js/jsNihonIME.js
@@ -614,7 +614,6 @@ function replacekana()
 
 
 	// Puts the temporary variable inside of the textbox
-	const answerInput = document.getElementById("answer-input");
 	if (answerInput) {
 		answerInput.value = str;
 	}


### PR DESCRIPTION
This commit fixes a 'SyntaxError: Identifier 'answerInput' has already been declared' error in `jsNihonIME.js`. The error was caused by a duplicate declaration of the `answerInput` constant.