### PR TITLE
I've restricted IME suggestions to the current quiz type. The IME was…

### DIFF
--- a/js/jsNihonIME.js
+++ b/js/jsNihonIME.js
@@ -773,6 +773,7 @@ function getKanjiSuggestions(input) {
                 partialMatches.push(char);
             }
         }
+        return [...new Set([...exactMatches, ...partialMatches])];
     } else if (quizState === 'hiraganaSpecial') {
         for (const char in characterSets.dakuten) {
             if (characterSets.dakuten[char].indexOf(input) !== -1) {
@@ -784,12 +785,14 @@ function getKanjiSuggestions(input) {
                 partialMatches.push(char);
             }
         }
+        return [...new Set([...exactMatches, ...partialMatches])];
     } else if (quizState === 'katakana') {
         for (const char in characterSets.katakana) {
             if (characterSets.katakana[char].indexOf(input) !== -1) {
                 partialMatches.push(char);
             }
         }
+        return [...new Set([...exactMatches, ...partialMatches])];
     }
 
     if (quizState === 'kanji') {


### PR DESCRIPTION
… showing kanji suggestions in hiragana and katakana quizzes. This change ensures that the IME only shows suggestions relevant to the current quiz type.