### PR TITLE
I've fixed the issue where the IME was showing kanji suggestions in h…

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,16 +1,3 @@
-function getKanjiSuggestions(input) {
-    const suggestions = [];
-    for (let level = 1; level <= 7; level++) {
-        const kanjiList = kanji(level);
-        for (let i = 0; i < kanjiList.length; i++) {
-            const kanjiInfo = kanjiList[i];
-            if (kanjiInfo.kun.indexOf(input) !== -1 || kanjiInfo.on.indexOf(input) !== -1) {
-                suggestions.push(kanjiInfo.char);
-            }
-        }
-    }
-    return suggestions;
-}
 // --- Service Worker and PWA ---
 
 // --- Dark Mode ---


### PR DESCRIPTION
…iragana and katakana quizzes. This was caused by a duplicate `getKanjiSuggestions` function in `js/script.js` that was overriding the intended function in `js/jsNihonIME.js`.

I've removed the duplicate function, so now the IME will only show suggestions relevant to the current quiz type.