### PR TITLE
Feature: Disable browser autocomplete for inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                 <div class="modal-body">
                     <div id="dictionary-search-container" style="display: none;">
                         <div class="input-group mb-3">
-                            <input type="text" class="form-control" placeholder="Search for a word..." id="dictionary-search-input">
+                            <input type="text" class="form-control" placeholder="Search for a word..." id="dictionary-search-input" autocomplete="off">
                             <button class="btn btn-outline-secondary" type="button" id="dictionary-search-button">Search</button>
                         </div>
                     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -374,7 +374,7 @@ function startQuiz(type) {
                 <h1 id="char-display" class="display-1"></h1>
                 <div id="example-word-area" class="mt-3"></div>
                 <div class="mb-3">
-                    <input type="text" class="form-control text-center" id="answer-input" onkeypress="if(event.key === 'Enter') document.getElementById('check-button').click()">
+                    <input type="text" class="form-control text-center" id="answer-input" autocomplete="off" onkeypress="if(event.key === 'Enter') document.getElementById('check-button').click()">
                 </div>
                 <div id="kanji-suggestions" class="mt-3"></div>
                 <button class="btn btn-success" id="check-button">Check</button>


### PR DESCRIPTION
This change disables the browser's autocomplete feature for the quiz answer input and the dictionary search input. This prevents the browser from showing a tooltip with past entries, which is not desired in this application.