### PR TITLE
This commit implements a new Developer Tools modal and fixes two crit…

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -646,7 +646,7 @@ const characterSets = {
     },
     kanji: {
         // Jouyou Kanji - Grade 1
-        '一': 'ichi', '二': 'ni', '三': 'san', '四': 'shi', '五': 'go', '六': 'roku', '七': 'shichi', '八': 'hachi', '九': 'kyuu', '十': 'juu', '百': 'hyaku', '千': 'sen', '万': 'man', '円': 'en', '時': 'ji', '日': 'nichi', '月': 'getsu', '火': 'ka', '水': 'sui', '木': 'moku', '金': 'kin', '土': 'do', '曜': 'you', '上': 'ue', '下': 'shita', '中': 'naka', '半': 'han', '山': 'yama', '川': 'kawa', '元': 'gen', '気': 'ki', '天': 'ten', '私': 'watashi', '今': 'ima', '田': 'ta', '女': 'onna', '男': 'otoko', '見': 'mi', '行': 'i', '食': 'ta', '飲': 'no',
+        '円': 'en', '時': 'ji', '日': 'nichi', '月': 'getsu', '火': 'ka', '水': 'sui', '木': 'moku', '金': 'kin', '土': 'do', '曜': 'you', '上': 'ue', '下': 'shita', '中': 'naka', '半': 'han', '山': 'yama', '川': 'kawa', '元': 'gen', '気': 'ki', '天': 'ten', '私': 'watashi', '今': 'ima', '田': 'ta', '女': 'onna', '男': 'otoko', '見': 'mi', '行': 'i', '食': 'ta', '飲': 'no',
         // Jouyou Kanji - Grade 2
         '語': 'go', '本': 'hon', '学生': 'gakusei', '学校': 'gakkou', '先生': 'sensei', '友': 'tomo', '達': 'dachi', '何': 'nan', '毎': 'mai', '朝': 'asa', '昼': 'hiru', '晩': 'ban', '時': 'toki', '分': 'fun', '半': 'han', '国': 'kuni', '人': 'jin', '会': 'a', '社': 'sha', '員': 'in', '医': 'i', '者': 'sha', '大': 'dai', '学': 'gaku', '高': 'kou', '校': 'kou', '小': 'shou', '中': 'chuu', '電': 'den', '車': 'sha', '自': 'ji', '転': 'ten', '乗': 'no', '駅': 'eki', '銀': 'gin', '行': 'kou', '郵': 'yuu', '便': 'bin', '局': 'kyoku', '図': 'to', '書': 'sho', '館': 'kan', '映': 'ei', '画': 'ga', '右': 'migi', '左': 'hidari', '前': 'mae', '後': 'ushiro', '外': 'soto', '東': 'higashi', '西': 'nishi', '南': 'minami', '北': 'kita', '名': 'na', '前': 'mae', '父': 'chichi', '母': 'haha', '子': 'ko', '供': 'domo', '犬': 'inu', '猫': 'neko', '鳥': 'tori', '魚': 'sakana', '花': 'hana', '肉': 'niku', '野菜': 'yasai', '果物': 'kudamono', '水': 'mizu', '茶': 'cha', '牛': 'gyuu', '乳': 'nyuu', '来': 'ki', '帰': 'kae', '聞': 'ki', '読': 'yo', '書': 'ka', '話': 'hana', '買': 'ka', '起': 'o', '寝': 'ne', '見': 'mi', '勉': 'ben', '強': 'kyou', '働': 'hatara', '休': 'yasu', '言': 'i', '思': 'omo', '知': 'shi', '入': 'hai', '出': 'de', '待': 'ma', '作': 'tsuku', '使': 'tsuka', '会': 'a', '同': 'ona', '楽': 'tano', '好': 'su', '嫌': 'kira', '上手': 'jouzu', '下手': 'heta', '元': 'gen', '気': 'ki', '病': 'byou', '院': 'in', '薬': 'kusuri', '速': 'haya', '遅': 'oso', '近': 'chika', '遠': 'too', '広': 'hiro', '狭': 'sema', '明': 'aka', '暗': 'kura', '暑': 'atsu', '寒': 'samu', '暖': 'atata', '涼': 'suzu', '静': 'shizu', '賑': 'nigi', '有名': 'yuumei', '親切': 'shinsetsu', '便利': 'benri', '不便': 'fuben', '元気': 'genki', '綺麗': 'kirei', '汚': 'kitana', '可愛': 'kawaii', '赤': 'aka', '青': 'ao', '白': 'shiro', '黒': 'kuro', '色': 'iro', '春': 'haru', '夏': 'natsu', '秋': 'aki', '冬': 'fuyu', '雨': 'ame', '雪': 'yuki', '風': 'kaze', '晴': 'ha', '曇': 'kumo', '空': 'sora', '海': 'umi', '山': 'yama', '川': 'kawa', '池': 'ike', '庭': 'niwa', '店': 'mise', '駅': 'eki', '道': 'michi', '部屋': 'heya', '家': 'ie', '会社': 'kaisha', '電話': 'denwa', '番号': 'bangou', '机': 'tsukue', '椅子': 'isu', '鞄': 'kaban', '靴': 'kutsu', '鉛筆': 'enpitsu' },
     numbers: {
@@ -886,8 +886,14 @@ function checkLevelUp(type) {
     if (allMastered) {
         playerState.levels[type]++;
         localStorage.setItem('nihon-player-state', JSON.stringify(playerState));
-        const newLevelName = characterLevels[type][playerState.levels[type]].name;
-        showToast("Topic Level Up!", `You've unlocked ${type}: ${newLevelName}!`);
+        const newLevel = characterLevels[type][playerState.levels[type]];
+        if (newLevel) {
+            // Add new characters to the current quiz session
+            Object.assign(currentCharset, newLevel.set);
+            initializeProgress(currentCharset); // Ensure new chars are in progress object
+            const newLevelName = newLevel.name;
+            showToast("Topic Level Up!", `You've unlocked ${type}: ${newLevelName}!`);
+        }
     }
 }
 


### PR DESCRIPTION
…ical bugs related to quiz progression and content duplication.

- **Developer Tools Modal:** The previous "secret code" implementation has been removed and replaced with a hidden Developer Tools modal. This modal can be unlocked by clicking the header of the Statistics modal 10 times. It provides UI buttons for resetting progress, backing up data to a JSON file, and restoring data from a backup.
- **Quiz Progression Fix:** A bug that caused quizzes to end prematurely after the first level was fixed. The `checkLevelUp` function now dynamically adds newly unlocked characters to the current quiz session, ensuring a continuous learning experience.
- **Skip Functionality Fix:** The "skip" button now correctly penalizes you by marking the skipped question as incorrect, preventing an exploit where you could master levels without answering questions.
- **Content De-duplication:** All number-related Kanji have been removed from the main Kanji data sets (`characterLevels` and `characterSets`) to prevent them from appearing in the Kanji quiz and reference sections, as they have their own dedicated "Numbers" section.