### PR TITLE
Fix ReferenceError for checkDevMode

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -57,6 +57,16 @@ function updateHomeButton(isSection) {
 }
 
 async function main() {
+    // --- Developer Tools ---
+    function checkDevMode() {
+        if (localStorage.getItem('nihon-dev-mode') === 'true') {
+            const devToolsButton = document.getElementById('dev-tools-button');
+            if (devToolsButton) {
+                devToolsButton.style.display = 'block';
+            }
+        }
+    }
+
     // --- Event Listeners and Initializations ---
 
     // Global click listener to close suggestions


### PR DESCRIPTION
This commit fixes a `ReferenceError` for the `checkDevMode` function. The function was being called before it was defined due to a refactoring error.

The `checkDevMode` function definition has been moved inside the `main` function in `js/script.js` to ensure it is in the correct scope when called.