### PR TITLE
Fix rapid question cycling and replace tooltips

### DIFF
--- a/js/jsNihonIME.js
+++ b/js/jsNihonIME.js
@@ -315,7 +315,14 @@ function katakana()
 
 
 /* Function that replaces the roman letters for their corresponding kana */
+let isProgrammaticChange = false;
+
 function replacekana(charset, quizType) {
+    if (isProgrammaticChange) {
+        isProgrammaticChange = false;
+        return;
+    }
+
     const answerInput = document.getElementById("answer-input");
     if (!answerInput) return;
 
@@ -339,6 +346,7 @@ function replacekana(charset, quizType) {
     }
 
     if (answerInput) {
+        isProgrammaticChange = true;
         answerInput.value = convertedText;
     }
 

--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,6 @@ let isDictionaryReady = false;
 let currentDictionaryStatusMessage = '';
 let currentCharset = {};
 let currentQuizType = '';
-let activeTooltip = null;
 let skipQueue = [];
 let progress = JSON.parse(localStorage.getItem('nihon-progress')) || {};
 let playerState = JSON.parse(localStorage.getItem('nihon-player-state')) || {
@@ -751,10 +750,6 @@ function getNextCharacter() {
 
 function showHomePage() {
     const contentArea = document.getElementById('content-area');
-    if (activeTooltip) {
-        activeTooltip.dispose();
-        activeTooltip = null;
-    }
     updateHomeButton(false);
 
     const suggestionsContainer = document.getElementById('kanji-suggestions-card');
@@ -1340,13 +1335,7 @@ async function loadQuestion(type) {
     document.getElementById('feedback-area').innerHTML = '';
     const p = progress[charToTest];
     if (!p.seen || p.lastAnswer === 'incorrect') {
-        const tooltip = new bootstrap.Tooltip(charDisplay, {
-            title: `Correct Answer: ${correctAnswer}`,
-            placement: 'top',
-            trigger: 'manual'
-        });
-        tooltip.show();
-        activeTooltip = tooltip;
+        showToast('Hint', `Correct Answer: ${correctAnswer}`);
         p.seen = true;
         localStorage.setItem('nihon-progress', JSON.stringify(progress));
     }
@@ -1358,10 +1347,6 @@ async function loadQuestion(type) {
     document.getElementById('check-button').disabled = false;
     document.getElementById('check-button').addEventListener('click', () => checkAnswer(charToTest, correctAnswer, type));
     document.getElementById('skip-button').addEventListener('click', () => {
-        if (activeTooltip) {
-            activeTooltip.dispose();
-            activeTooltip = null;
-        }
         p.incorrect++;
         p.streak = 0;
         p.lastAnswer = 'incorrect';
@@ -1385,10 +1370,6 @@ async function loadQuestion(type) {
 }
 
 function checkAnswer(char, correctAnswer, type) {
-    if (activeTooltip) {
-        activeTooltip.dispose();
-        activeTooltip = null;
-    }
     const answerInput = document.getElementById('answer-input');
     let userAnswer = wanakana.toRomaji(answerInput.value.trim());
     const feedbackArea = document.getElementById('feedback-area');


### PR DESCRIPTION
This commit fixes a bug that caused rapid question cycling and replaces the hint tooltips with toast notifications.

The main changes are:

1.  **Fix Rapid Question Cycling:** An infinite loop in the `input` event handler for the answer field was causing questions to cycle rapidly. This was fixed by introducing a flag to prevent the event handler from running when the input value is changed programmatically.

2.  **Replace Tooltips with Toasts:** The Bootstrap tooltips used to show hints have been removed and replaced with toast notifications, as requested.