### PR TITLE
feat: Add Playwright for end-to-end testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ replacements.txt
 history.txt
 status.txt
 example/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -43,3 +43,39 @@ Nihon is a comprehensive Progressive Web App (PWA) for learning the Japanese lan
     - **Wanakana.js:** For robust Romaji-to-Kana conversion.
     - **Popper.js:** For interactive tooltips.
     - **Bootstrap:** For UI components and styling.
+
+## Testing
+
+This project uses Playwright for end-to-end testing.
+
+### Setup
+
+1.  Install the project dependencies:
+    ```bash
+    npm install
+    ```
+
+2.  Install the Playwright browsers:
+    ```bash
+    npx playwright install
+    ```
+
+### Running the Tests
+
+1.  Start the local development server:
+    ```bash
+    npm start
+    ```
+
+2.  In a separate terminal, run the tests:
+
+    -   To run all tests:
+        ```bash
+        npm test
+        ```
+
+    -   To run a specific set of tests (e.g., only the quiz feature):
+        ```bash
+        npm test -- --grep "Quiz"
+        ```
+        You can replace `"Quiz"` with `"Flashcards"` or `"Modals"` to run other specific tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2",
+        "playwright": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "description": "Nihon is a comprehensive Progressive Web App (PWA) for learning the Japanese language. It offers a modern, gamified experience to help users master everything from basic characters to complex sentences.",
+  "main": "sw.js",
+  "scripts": {
+    "start": "http-server -p 8080",
+    "test": "playwright test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/santanderelias/nihon.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/santanderelias/nihon/issues"
+  },
+  "homepage": "https://github.com/santanderelias/nihon#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.40.1",
+    "http-server": "^14.1.1",
+    "playwright": "^1.54.2"
+  }
+}

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,0 +1,112 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const baseURL = 'http://localhost:8080';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(baseURL);
+});
+
+test.describe('Comprehensive Smoke Test', () => {
+  test('should load the homepage and display learning sections', async ({ page }) => {
+    await expect(page.locator('h2')).toHaveText('Learning Sections');
+    await expect(page.locator('.card')).toHaveCount(7);
+  });
+
+  test('should start a hiragana quiz and check for question', async ({ page }) => {
+    await page.click('#quizHiragana');
+    await expect(page.locator('#char-display')).toBeVisible();
+    await expect(page.locator('#answer-input')).toBeVisible();
+    await expect(page.locator('#check-button')).toBeVisible();
+  });
+
+  test('should go back to home from a quiz', async ({ page }) => {
+    await page.click('#quizHiragana');
+    await page.click('#home-button');
+    await expect(page.locator('h2')).toHaveText('Learning Sections');
+  });
+
+  test('should start hiragana flashcards and flip a card', async ({ page }) => {
+    await page.click('#flashcardHiragana');
+    await expect(page.locator('.flashcard')).toBeVisible();
+    await page.click('#flip-button');
+    await expect(page.locator('.flashcard')).toHaveClass(/flipped/);
+  });
+
+  test('should open and close the stats modal', async ({ page }) => {
+    await page.click('#stats-button');
+    await expect(page.locator('#stats-modal')).toBeVisible();
+    await expect(page.locator('#statsModalLabel')).toHaveText('Statistics');
+    await page.locator('#stats-modal .btn-close').click();
+    await expect(page.locator('#stats-modal')).not.toBeVisible();
+  });
+
+  test('should open and close the dictionary modal', async ({ page }) => {
+    await page.click('#dictionary-button');
+    await expect(page.locator('#dictionary-modal')).toBeVisible();
+    await expect(page.locator('#dictionaryModalLabel')).toHaveText('Dictionary');
+    await page.locator('#dictionary-modal .btn-close').click();
+    await expect(page.locator('#dictionary-modal')).not.toBeVisible();
+  });
+
+  test('should open and close the grammar modal', async ({ page }) => {
+    await page.click('#grammar-button');
+    await expect(page.locator('#grammar-modal')).toBeVisible();
+    await expect(page.locator('#grammarModalLabel')).toHaveText('Grammar');
+    await page.locator('#grammar-modal .btn-close').click();
+    await expect(page.locator('#grammar-modal')).not.toBeVisible();
+  });
+
+  test('should open and close the references modal', async ({ page }) => {
+    await page.click('#references-button');
+    await expect(page.locator('#references-modal')).toBeVisible();
+    await expect(page.locator('#referencesModalLabel')).toHaveText('References');
+    await page.locator('#references-modal .btn-close').click();
+    await expect(page.locator('#references-modal')).not.toBeVisible();
+  });
+});
+
+test.describe('Feature: Quiz', () => {
+    test('should allow answering a question in hiragana quiz', async ({ page }) => {
+        await page.click('#quizHiragana');
+        const charToTest = await page.locator('#char-display').innerText();
+        // This is a simple test, so we'll just type something and check.
+        // A more robust test would need to know the correct answer.
+        await page.fill('#answer-input', 'a');
+        await page.click('#check-button');
+        await expect(page.locator('#feedback-area')).toBeVisible();
+    });
+
+    test('should show a hint in the quiz', async ({ page }) => {
+        await page.click('#quizKatakana');
+        await page.click('#hint-button');
+        await expect(page.locator('#hint-display')).toBeVisible();
+        await expect(page.locator('#hint-display')).toContainText('Hint:');
+    });
+});
+
+test.describe('Feature: Flashcards', () => {
+    test('should allow marking a flashcard as true or false', async ({ page }) => {
+        await page.click('#flashcardKatakana');
+        await expect(page.locator('.flashcard')).toBeVisible();
+        await page.click('#true-button');
+        await expect(page.locator('#feedback-area')).toBeVisible();
+        // Wait for the next card to load
+        await page.waitForTimeout(1500);
+        await page.click('#false-button');
+        await expect(page.locator('#feedback-area')).toBeVisible();
+    });
+});
+
+test.describe('Feature: Modals', () => {
+    test('should be able to switch tabs in references modal', async ({ page }) => {
+        await page.click('#references-button');
+        await expect(page.locator('#references-modal')).toBeVisible();
+        await page.click('#katakana-tab');
+        await expect(page.locator('#katakana')).toHaveClass(/active/);
+        await page.click('#kanji-tab');
+        await expect(page.locator('#kanji')).toHaveClass(/active/);
+        await page.click('#numbers-tab');
+        await expect(page.locator('#numbers')).toHaveClass(/active/);
+    });
+});


### PR DESCRIPTION
This commit introduces Playwright for end-to-end testing of the application.

A new `tests/e2e.spec.js` file has been created with a comprehensive smoke test that covers the main features of the application, as well as specific tests for the quiz, flashcards, and modals.

The `package.json` file has been updated with a `test` script to run the Playwright tests and a `start` script to serve the application. The necessary Playwright and http-server dependencies have also been added.

The `README.md` file has been updated with a new 'Testing' section that provides instructions on how to install the dependencies and run the tests.