### PR TITLE
feat: Add eruda for on-device debugging

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#212529">
     <link rel="icon" href="/nihon/favicon.ico" sizes="any">
+    <script src="https://cdn.jsdelivr.net/npm/eruda"></script>
+    <script>
+        eruda.init();
+        eruda.show();
+    </script>
 </head>
 <body>
 


### PR DESCRIPTION
This commit adds the eruda library to the `index.html` file. Eruda is a console for mobile browsers that will help with on-device debugging of JavaScript errors.

The library is loaded and initialized in the `<head>` of the document to ensure it captures all logs and errors, including those that occur during page load.

Note: The existing test suite is failing. The errors (`ReferenceError: Worker is not defined`, `ReferenceError: playerState is not defined`, etc.) appear to be related to the test environment setup (JSDOM's lack of Worker support) and pre-existing issues in the application logic, rather than the changes introduced in this commit.