### PR TITLE
fix: Export missing functions from flashcards module

### DIFF
--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -134,11 +134,11 @@ function loadFlashcard(type) {
     flashcardMeaning.textContent = meaning;
 }
 
-function flipFlashcard() {
+export function flipFlashcard() {
     document.getElementById('flashcard').classList.toggle('flipped');
 }
 
-function checkFlashcardAnswer(userAnswer, type) {
+export function checkFlashcardAnswer(userAnswer, type) {
     const isCorrect = (userAnswer === isCurrentCardCorrect);
     markFlashcardProgress(currentFlashcardChar, isCorrect, type);
 }


### PR DESCRIPTION
This commit adds the missing `export` statements to the `flipFlashcard` and `checkFlashcardAnswer` functions in `js/flashcards.js`.

This resolves the "module does not provide an export named..." error and makes the flashcard functionality work as intended.