### PR TITLE
fix: Export missing function from quiz module

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -97,7 +97,7 @@ function getNextCharacter() {
     return fallbackChar || unlockedChars[Math.floor(Math.random() * unlockedChars.length)];
 }
 
-async function loadQuestion(type) {
+export async function loadQuestion(type) {
     const contentArea = document.getElementById('content-area');
     const charToTest = state.nextChar;
 


### PR DESCRIPTION
This commit adds the missing `export` statement to the `loadQuestion` function in `js/quiz.js`.

This resolves the "module does not provide an export named..." error that would have occurred after the last fix. This should make the quiz functionality work as intended.